### PR TITLE
Update ‘Roomify Property’ to v. 1.18

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -34,7 +34,7 @@ projects[roomify_rate][subdir] = roomify
 projects[roomify_property][type] = module
 projects[roomify_property][download][type] = git
 projects[roomify_property][download][url] = https://github.com/Roomify/roomify_property.git
-projects[roomify_property][download][tag] = 1.17
+projects[roomify_property][download][tag] = 1.18
 projects[roomify_property][directory_name] = roomify_property
 projects[roomify_property][subdir] = roomify
 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -34,7 +34,7 @@ projects[roomify_rate][subdir] = roomify
 projects[roomify_property][type] = module
 projects[roomify_property][download][type] = git
 projects[roomify_property][download][url] = https://github.com/Roomify/roomify_property.git
-projects[roomify_property][download][tag] = 1.16
+projects[roomify_property][download][tag] = 1.17
 projects[roomify_property][directory_name] = roomify_property
 projects[roomify_property][subdir] = roomify
 


### PR DESCRIPTION
If a Roomify Property entity provides a translation it's impossible to edit that. The new version of the roomify_property module fixes the issue.