### PR TITLE
The following module is missing from the file system: module_filter

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -67,6 +67,9 @@ projects[bootstrap][version] = 3.8
 ; adminimal
 projects[adminimal_theme][type] = theme
 projects[adminimal_theme][version] = 1.24
+; Fix issue with module_filter not being detected.
+; See: https://www.drupal.org/node/2763581
+projects[adminimal_theme][patch][] = "https://www.drupal.org/files/issues/adminimal_theme_1_24-2763581-34_0.patch"
 
 ; +++++ Contrib Modules +++++
 


### PR DESCRIPTION
`User warning: The following module is missing from the file system: module_filter. For information about how to fix this, see the documentation page. in _drupal_trigger_error_with_delayed_logging() (line 1128 of C:\wamp\www\rfa12\includes\bootstrap.inc)
`

I believe this only happens on the packaged version.