### PR TITLE
Image pushes map tooltip off of screen

### DIFF
--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -11393,26 +11393,29 @@ ol.inline.commerce-checkout-progress {
           margin-left: 2%;
           text-align: left;
           padding-left: 0; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
-  max-width: 250px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
-  font-size: 18px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
-  margin: 5px 0;
-  font-size: 15px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
-  display: inline-block;
-  max-width: 250px;
-  margin: 5px 0; }
-  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img,
-  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
-    width: 100% !important;
-    border-radius: 5px;
-    min-width: 120px; }
+.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup,
+.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup {
+  height: 250px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
+    max-width: 170px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
+    font-size: 18px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
+    margin: 5px 0;
+    font-size: 15px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
+    display: inline-block;
+    max-width: 250px;
+    margin: 5px 0; }
+    .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img,
+    .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
+      width: 100% !important;
+      border-radius: 2px;
+      min-width: 120px; }
 
 #property-bat-activity-facets-availability .form-wrapper,
 #roomify-property-search-block-form .form-wrapper,

--- a/themes/roomify/roomify_travel/assets/sass/pages/_availability-search.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_availability-search.scss
@@ -506,8 +506,9 @@
   .view-display-id-panel_pane_2 {
     #leaflet-map {
       .leaflet-popup {
+        height: 250px;
         .leaflet-popup-content {
-          max-width: 250px;
+          max-width: 170px;
         }
         a {
           font-size: 18px;
@@ -522,7 +523,7 @@
           margin: 5px 0;
           img {
             width: 100% !important;
-            border-radius: 5px;
+            border-radius: 2px;
             min-width: 120px;
           }
         }


### PR DESCRIPTION
On the map search, if a pin is near the top of the screen, one can see the title at first, and then after the image loads it disappears:

![tooltip](https://cloud.githubusercontent.com/assets/101649/21566987/badcf4f2-ce65-11e6-80b8-3a546953918c.png)

Not sure about the best approach, we could consider centering the map on the pin when it is clicked, but that could be annoying... @cecrs @salvoscala what do you think?