### PR TITLE
Improve language fallback of properties fields

### DIFF
--- a/modules/roomify/roomify_i18n/roomify_i18n.module
+++ b/modules/roomify/roomify_i18n/roomify_i18n.module
@@ -23,7 +23,6 @@ function roomify_i18n_form_alter(&$form, &$form_state, $form_id) {
   if (isset($form['translation']) && $form['translation']['#type'] == 'fieldset') {
     $form['translation']['#group'] = 'additional_settings';
   }
-
 }
 
 /**
@@ -46,7 +45,6 @@ function roomify_i18n_entities_translation_settings() {
  * Implements hook_roomify_rights().
  */
 function roomify_i18n_roomify_rights() {
-
   $rights['roomify_i18n'] = array(
     'roomify manager' => array(
       'translate node entities',

--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -1834,7 +1834,7 @@ function roomify_system_menu_local_tasks_alter(&$data, $router_item, $root_path)
  * Implements hook_views_query_alter().
  */
 function roomify_system_views_query_alter(&$view, &$query) {
-  if (($view->name == 'property' && $view->current_display == 'panel_pane_1') || ($view->name == 'property_slideshow' && $view->current_display == 'default')) {
+  if ($view->name == 'property' && $view->current_display == 'panel_pane_1') {
     if ($property = roomify_property_load($view->args[0])) {
       global $language_content;
 
@@ -1847,6 +1847,23 @@ function roomify_system_views_query_alter(&$view, &$query) {
 
       $query->where[0]['conditions'][1]['value'][':field_data_field_sp_gallery_field_sp_gallery'] = array($current_language);
       $query->where[0]['conditions'][2]['value'][':field_data_field_sp_gallery_field_sp_gallery1'] = array($current_language);
+    }
+  }
+
+  if ($view->name == 'property_slideshow' && $view->current_display == 'default') {
+    if ($property = roomify_property_load($view->args[0])) {
+      global $language_content;
+
+      if (isset($property->translations->data[$language_content->language])) {
+        $current_language = $language_content->language;
+      }
+      else {
+        $current_language = $property->language;
+      }
+
+      $query->where[0]['conditions'][1]['value'][':field_data_field_sp_gallery_field_sp_gallery'] = array($current_language);
+      $query->where[0]['conditions'][2]['value'][':field_data_field_sp_gallery_field_sp_gallery1'] = array($current_language);
+      $query->where[0]['conditions'][3]['value'][':field_data_field_sp_gallery_field_sp_gallery2'] = array($current_language);
     }
   }
 

--- a/modules/roomify/roomify_translate/roomify_translate.module
+++ b/modules/roomify/roomify_translate/roomify_translate.module
@@ -108,3 +108,18 @@ function roomify_translate_entities_translation_settings() {
   variable_set('entity_translation_settings_bat_type__home', $settings);
   variable_set('entity_translation_settings_bat_type__room', $settings);
 }
+
+/**
+ * Implements hook_language_fallback_candidates_alter().
+ */
+function roomify_translate_language_fallback_candidates_alter(array &$fallback_candidates) {
+  global $language;
+
+  $menu_item = menu_get_item();
+
+  if ($menu_item['path'] == 'listing/%' || $menu_item['path'] == 'room-type/%') {
+    if (isset($menu_item['page_arguments'][1]->data->translations->data[$language->language])) {
+      $fallback_candidates = array($language->language, LANGUAGE_NONE);
+    }
+  }
+}


### PR DESCRIPTION
If in a property there's a translation with empty fields we shouldn't show the source field but the empty text.