### PR TITLE
Metatag support for Roomify Properties and Bat Entities

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -9,7 +9,7 @@ defaults[projects][subdir] = contrib
 projects[bat][type] = module
 projects[bat][download][type] = git
 projects[bat][download][url] = https://github.com/Roomify/bat_drupal.git
-projects[bat][download][tag] = 7.x-1.16
+projects[bat][download][tag] = 7.x-1.17
 projects[bat][subdir] = bat
 
 projects[bat_api][type] = module
@@ -34,7 +34,7 @@ projects[roomify_rate][subdir] = roomify
 projects[roomify_property][type] = module
 projects[roomify_property][download][type] = git
 projects[roomify_property][download][url] = https://github.com/Roomify/roomify_property.git
-projects[roomify_property][download][tag] = 1.19
+projects[roomify_property][download][tag] = 1.20
 projects[roomify_property][directory_name] = roomify_property
 projects[roomify_property][subdir] = roomify
 

--- a/modules/roomify/roomify_listing/roomify_listing.install
+++ b/modules/roomify/roomify_listing/roomify_listing.install
@@ -31,6 +31,15 @@ function roomify_listing_install() {
   roomify_listing_create_pricing_event_type();
 
   variable_set('dragdropfile_default_enabled', 0);
+
+  // Enable metatags on Type and Property.
+  variable_set('metatag_enable_bat_type', 1);
+  variable_set('metatag_enable_bat_type__home', 1);
+  variable_set('metatag_enable_bat_type__room', 1);
+
+  variable_set('metatag_enable_roomify_property', 1);
+  variable_set('metatag_enable_roomify_property__casa_property', 1);
+  variable_set('metatag_enable_roomify_property__locanda_property', 1);
 }
 
 /**
@@ -1119,4 +1128,17 @@ function roomify_listing_update_7023() {
     $field_group->children[4] = 'field_rates_ranges';
     field_group_group_save($field_group);
   }
+}
+
+/**
+ * Enable metatags on Type and Property.
+ */
+function roomify_listing_update_7024() {
+  variable_set('metatag_enable_bat_type', 1);
+  variable_set('metatag_enable_bat_type__home', 1);
+  variable_set('metatag_enable_bat_type__room', 1);
+
+  variable_set('metatag_enable_roomify_property', 1);
+  variable_set('metatag_enable_roomify_property__casa_property', 1);
+  variable_set('metatag_enable_roomify_property__locanda_property', 1);
 }

--- a/modules/roomify/roomify_pages_manager/roomify_pages_manager.module
+++ b/modules/roomify/roomify_pages_manager/roomify_pages_manager.module
@@ -13,3 +13,37 @@ function roomify_pages_manager_ctools_plugin_api($module = NULL, $api = NULL) {
     return array("version" => "1");
   }
 }
+
+/**
+ * Implements hook_ctools_render_alter().
+ *
+ * Temporary solution to load meta tags on entity pages that are driven by
+ * CTools display handlers.
+ */
+function roomify_pages_manager_ctools_render_alter(&$info, $page, $context) {
+  if ($page && isset($context['subtask']['admin path'])) {
+    if ($context['subtask']['admin path'] == 'listing/%type_id' || $context['subtask']['admin path'] == 'room-type/%type_id') {
+      // Loop over each context.
+      foreach ($context['contexts'] as $context_argument) {
+        if (is_array($context_argument->type) && !empty($context_argument->data)) {
+          if (in_array('entity', $context_argument->type)) {
+            $entity = $context_argument->data;
+            $entity_type = str_replace('entity:', '', $context_argument->plugin);
+
+            // Verify this is an appropriate entity.
+            $entity_info = entity_get_info($entity_type);
+            if (!empty($entity_info) && _metatag_entity_is_page($entity_type, $entity)) {
+              // Load the meta tags for this entity.
+              global $language;
+              metatag_entity_view($entity, $entity_type, 'full', $language->language, TRUE);
+
+              // Don't bother looping over any more contexts, an entity has been
+              // found.
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -874,6 +874,7 @@ function roomify_system_roomify_rights() {
       'delete own bat_unit entities',
       'unpublish own property',
       'unpublish own type',
+      'edit meta tags',
     ),
     'roomify manager' => array(
       'administer fields',
@@ -982,6 +983,7 @@ function roomify_system_roomify_rights() {
       'view files',
       'administer roomify availability form settings',
       'administer roomify_customer_support',
+      'edit meta tags',
     ),
     'content editor' => array(
       'access content overview',
@@ -1007,6 +1009,7 @@ function roomify_system_roomify_rights() {
       'view own private files',
       'view own files',
       'administer theme colors',
+      'edit meta tags',
     ),
     'administrator' => $permissions,
   );


### PR DESCRIPTION
Administrators, Roomify managers, Property owners and Content editor roles should be able to manage metatags on those entities.