### PR TITLE
Roomify Manager role should have permission to administer theme colors

### DIFF
--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -984,6 +984,7 @@ function roomify_system_roomify_rights() {
       'administer roomify availability form settings',
       'administer roomify_customer_support',
       'edit meta tags',
+      'administer theme colors',
     ),
     'content editor' => array(
       'access content overview',
@@ -1008,7 +1009,6 @@ function roomify_system_roomify_rights() {
       'create files',
       'view own private files',
       'view own files',
-      'administer theme colors',
       'edit meta tags',
     ),
     'administrator' => $permissions,


### PR DESCRIPTION
Right now, only the content editor role has this permission.