### PR TITLE
Only enable required modules when an integration is enabled

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -423,6 +423,9 @@ projects[timefield][version] = 1.0-alpha2
 projects[title][version] = 1.0-alpha8
 
 projects[token][version] = 1.6
+; Patch the module because descriptions of boolean fields are not translatable.
+; Make sure to test that translations work properly before removing this patch.
+projects[token][patch][] = https://www.drupal.org/files/issues/token-token-prevents-display-of-i18n-field-description-2367721-3.patch
 
 projects[userone][version] = 1.0-beta1
 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -163,11 +163,6 @@ projects[diff][version] = 3.3
 
 projects[dragdropfile][version] = 1.7
 
-projects[editablefields][type] = module
-projects[editablefields][download][type] = git
-projects[editablefields][download][url] = https://git.drupal.org/project/editablefields.git
-projects[editablefields][download][revision] = 97f0c29a8ad87c72d3244bc70dbffb8b4af39388
-
 projects[elements][version] = 1.4
 
 projects[email][version] = 1.3

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -919,8 +919,7 @@ function roomify_accommodation_booking_confirmation_form($form, &$form_state, $s
     if (variable_get('roomify_accommodation_booking_allow_instant_bookings', 1)) {
       if (isset($property->field_sp_allow_instant_bookings[LANGUAGE_NONE][0]['value']) &&
           $property->field_sp_allow_instant_bookings[LANGUAGE_NONE][0]['value']) {
-        if (isset($type->field_st_allow_instant_bookings[LANGUAGE_NONE][0]['value']) &&
-            $type->field_st_allow_instant_bookings[LANGUAGE_NONE][0]['value']) {
+        if ($type->type == 'home' || (!empty($type->field_st_allow_instant_bookings[LANGUAGE_NONE][0]['value']))) {
           $form['submit'] = array(
             '#type' => 'submit',
             '#value' => t('Confirm booking'),

--- a/modules/roomify/roomify_base_theme/roomify_base_theme.pages_default.inc
+++ b/modules/roomify/roomify_base_theme/roomify_base_theme.pages_default.inc
@@ -60,7 +60,7 @@ function roomify_base_theme_default_page_manager_handlers() {
     ),
   );
   $display->cache = array();
-  $display->title = '';
+  $display->title = '%node:title_field';
   $display->uuid = 'bdfbe48f-f065-4ea6-9330-0aca5c08a60f';
   $display->storage_type = 'page_manager';
   $display->storage_id = 'node_view__blog_post';
@@ -512,7 +512,7 @@ function roomify_base_theme_default_page_manager_handlers() {
     ),
   );
   $display->cache = array();
-  $display->title = '';
+  $display->title = '%node:title_field';
   $display->uuid = 'b4a8fd8a-aced-42ab-b4a8-2f0f0f6e43b3';
   $display->storage_type = 'page_manager';
   $display->storage_id = 'node_view__activity';
@@ -741,7 +741,7 @@ function roomify_base_theme_default_page_manager_handlers() {
     ),
   );
   $display->cache = array();
-  $display->title = '';
+  $display->title = '%node:title_field';
   $display->uuid = '9ef84618-1857-465c-a31a-7230c09fde85';
   $display->storage_type = 'page_manager';
   $display->storage_id = 'node_view__location';

--- a/modules/roomify/roomify_integrations/css/roomify_integrations.css
+++ b/modules/roomify/roomify_integrations/css/roomify_integrations.css
@@ -1,18 +1,23 @@
-#roomify-integrations-form .zopim-integration a {
+#roomify-manage-integrations-form .zopim-integration a {
   display: inline-block;
   width: 100%;
   float: left;
   color: black;
 }
-
-#roomify-integrations-form .zopim-integration a img {
+#roomify-manage-integrations-form  .zopim-integration a img {
   float: left;
   margin-right: 15px;
   width: 70px;
   height: auto;
 }
-
-#roomify-integrations-form .zopim-integration a h3 {
+#roomify-manage-integrations-form  .zopim-integration a h3 {
   margin-bottom: 13px;
   margin-top: 15px;
+}
+#roomify-integrations-form input.form-submit {
+  margin-top: 20px;
+}
+#roomify-manage-integrations-form,
+#roomify-integrations-form h2 {
+  margin-bottom: 20px;
 }

--- a/modules/roomify/roomify_integrations/roomify_integrations.info
+++ b/modules/roomify/roomify_integrations/roomify_integrations.info
@@ -7,4 +7,3 @@ dependencies[] = page_manager
 dependencies[] = panels_mini
 dependencies[] = views
 dependencies[] = views_content
-dependencies[] = zopim

--- a/modules/roomify/roomify_integrations/roomify_integrations.install
+++ b/modules/roomify/roomify_integrations/roomify_integrations.install
@@ -6,6 +6,49 @@
  */
 
 /**
+ * Implements hook_schema().
+ */
+function roomify_integrations_schema() {
+  $schema = array();
+
+  $schema['roomify_integrations'] = array(
+    'description' => 'The base table for Roomify Integrations.',
+    'fields' => array(
+      'name' => array(
+        'description' => 'The name of the Integration - a machine-name identifier.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'label' => array(
+        'description' => 'The Label of the Integration - a human-readable identifier.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'status' => array(
+        'description' => 'Boolean indicating whether the integration is enabled',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('name'),
+  );
+
+  return $schema;
+}
+
+/**
+ * Implements hook_install().
+ */
+function roomify_integrations_install() {
+  _roomify_integrations_check_zopim();
+}
+
+/**
  * Implements hook_uninstall().
  */
 function roomify_integrations_uninstall() {
@@ -13,16 +56,31 @@ function roomify_integrations_uninstall() {
 }
 
 /**
- * Improve Integrations.
+ * Check if Zopim is enabled or not.
  */
-function roomify_integrations_update_7001() {
+function _roomify_integrations_check_zopim() {
+  $zopim_status = 0;
   if (module_exists('zopim')) {
     // Is set a zopim account, leave the module enabled.
     if (variable_get('zopim_account', '') != '') {
-      variable_set('roomify_integration_zopim', 1);
+      $zopim_status = 1;
     }
     else {
       module_disable(array('zopim'));
     }
   }
+  $record = array(
+    'name' => 'zopim',
+    'label' => 'Zopim',
+    'status' => $zopim_status,
+  );
+  drupal_write_record('roomify_integrations', $record);
+}
+
+/**
+ * Add the Roomfiy Integrations table and update zopim status.
+ */
+function roomify_integrations_update_7001() {
+  db_create_table('roomify_integrations', drupal_get_schema_unprocessed('roomify_integrations', 'roomify_integrations'));
+  _roomify_integrations_check_zopim();
 }

--- a/modules/roomify/roomify_integrations/roomify_integrations.install
+++ b/modules/roomify/roomify_integrations/roomify_integrations.install
@@ -6,13 +6,6 @@
  */
 
 /**
- * Implements hook_install().
- */
-function roomify_integrations_install() {
-
-}
-
-/**
  * Implements hook_uninstall().
  */
 function roomify_integrations_uninstall() {

--- a/modules/roomify/roomify_integrations/roomify_integrations.install
+++ b/modules/roomify/roomify_integrations/roomify_integrations.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Installation for roomify_integrations.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function roomify_integrations_install() {
+
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function roomify_integrations_uninstall() {
+  variable_del('roomify_integration_zopim');
+}
+
+/**
+ * Improve Integrations.
+ */
+function roomify_integrations_update_7001() {
+  if (module_exists('zopim')) {
+    // Is set a zopim account, leave the module enabled.
+    if (variable_get('zopim_account', '') != '') {
+      variable_set('roomify_integration_zopim', 1);
+    }
+    else {
+      module_disable(array('zopim'));
+    }
+  }
+}

--- a/modules/roomify/roomify_integrations/roomify_integrations.module
+++ b/modules/roomify/roomify_integrations/roomify_integrations.module
@@ -70,14 +70,25 @@ function roomify_integrations_form($form, &$form_state) {
     '#markup' => '<h2>' . t("Here you can find a list of Integration to enable.") . '</h2>',
   );
 
-  $form['roomify_integration_zopim'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable Zopim Integration'),
-    '#default_value' => variable_get('roomify_integration_zopim', 0),
+  $integrations = db_select('roomify_integrations', 'i')
+    ->fields('i')
+    ->execute()
+    ->fetchAll();
+
+  foreach ($integrations as $integration) {
+    $form['roomify_integration'][$integration->name] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable @integration Integration', array('@integration' => $integration->label)),
+      '#default_value' => $integration->status,
+    );
+  }
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save Configuration'),
   );
 
-  $form['#submit'][] = 'roomify_integrations_form_submit';
-  return system_settings_form($form);
+  return $form;
 }
 
 /**
@@ -85,18 +96,26 @@ function roomify_integrations_form($form, &$form_state) {
  */
 function roomify_integrations_form_submit(&$form, &$form_state) {
   $values = $form_state['values'];
-
-  if (isset($values['roomify_integration_zopim'])) {
-    if ($values['roomify_integration_zopim'] == 1) {
+  if (isset($values['zopim'])) {
+    if ($values['zopim'] == 1) {
+      $zopim_status = 1;
       if (!module_exists('zopim')) {
         module_enable(array('zopim'));
       }
     }
     else {
+      $zopim_status = 0;
       if (module_exists('zopim')) {
         module_disable(array('zopim'));
       }
     }
+    $record = array(
+      'name' => 'zopim',
+      'label' => 'Zopim',
+      'status' => $zopim_status,
+    );
+
+    drupal_write_record('roomify_integrations', $record, array('name'));
     menu_rebuild();
   }
 }
@@ -112,13 +131,21 @@ function roomify_manage_integrations_form($form, &$form_state) {
   );
   $form['#attached']['css'] = array($module_path . '/css/roomify_integrations.css');
 
-  if (variable_get('roomify_integration_zopim', 0) == 1) {
-    $zopim_path = '/admin/config/system/zopim';
-    $zopim_image = theme_image(array('path' => $module_path . '/images/zopim.png', 'attributes' => ''));
+  $integrations = db_select('roomify_integrations', 'i')
+    ->fields('i')
+    ->condition('status', 1, '=')
+    ->execute()
+    ->fetchAll();
 
-    $form['zopim'] = array(
-      '#markup' => '<div class="zopim-integration">' . l($zopim_image . '<h3>' . t('Zopim Chat') . '</h3>' . t('Talk to your customers in real-time using a live chat.'), $zopim_path, array('html' => TRUE)) . '</div>'
-    );
+  foreach ($integrations as $integration) {
+    if ($integration->name == 'zopim') {
+      $zopim_path = '/admin/config/system/zopim';
+      $zopim_image = theme_image(array('path' => $module_path . '/images/zopim.png', 'attributes' => ''));
+
+      $form['zopim'] = array(
+        '#markup' => '<div class="zopim-integration">' . l($zopim_image . '<h3>' . t('Zopim Chat') . '</h3>' . t('Talk to your customers in real-time using a live chat.'), $zopim_path, array('html' => TRUE)) . '</div>'
+      );
+    }
   }
 
   return $form;

--- a/modules/roomify/roomify_integrations/roomify_integrations.module
+++ b/modules/roomify/roomify_integrations/roomify_integrations.module
@@ -67,7 +67,7 @@ function roomify_integrations_form($form, &$form_state) {
   $module_path = drupal_get_path('module', 'roomify_integrations');
   $form['#attached']['css'] = array($module_path . '/css/roomify_integrations.css');
   $form['roomify_integration_intro'] = array(
-    '#markup' => '<h2>' . t("Here you can find a list of Integration to enable.") . '</h2>',
+    '#markup' => '<h2>' . t("Here you can find a list of integrations to enable.") . '</h2>',
   );
 
   $integrations = db_select('roomify_integrations', 'i')

--- a/modules/roomify/roomify_integrations/roomify_integrations.module
+++ b/modules/roomify/roomify_integrations/roomify_integrations.module
@@ -12,10 +12,23 @@ function roomify_integrations_menu() {
   $items = array();
 
   $items['admin/config/roomify-integrations'] = array(
-    'title' => 'Roomify Integrations',
+    'title' => 'Enable Roomify Integrations',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('roomify_integrations_form'),
     'access arguments' => array('administer roomify integrations'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['admin/config/roomify-integrations/enable'] = array(
+    'title' => 'Enable Roomify Integrations',
+    'access arguments' => array('administer roomify integrations'),
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+  );
+  $items['admin/config/roomify-integrations/manage'] = array(
+    'title' => 'Manage Roomify Integrations',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('roomify_manage_integrations_form'),
+    'access arguments' => array('administer roomify integrations'),
+    'type' => MENU_LOCAL_TASK,
   );
 
   return $items;
@@ -48,23 +61,65 @@ function roomify_integrations_roomify_rights() {
 }
 
 /**
- * Form "Roomify Integrations".
+ * Form Enable "Roomify Integrations".
  */
 function roomify_integrations_form($form, &$form_state) {
   $module_path = drupal_get_path('module', 'roomify_integrations');
-
-  $zopim_path = '/admin/config/system/zopim';
-  $zopim_image = theme_image(array('path' => $module_path . '/images/zopim.png', 'attributes' => ''));
-
   $form['#attached']['css'] = array($module_path . '/css/roomify_integrations.css');
+  $form['roomify_integration_intro'] = array(
+    '#markup' => '<h2>' . t("Here you can find a list of Integration to enable.") . '</h2>',
+  );
+
+  $form['roomify_integration_zopim'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Zopim Integration'),
+    '#default_value' => variable_get('roomify_integration_zopim', 0),
+  );
+
+  $form['#submit'][] = 'roomify_integrations_form_submit';
+  return system_settings_form($form);
+}
+
+/**
+ * Enable or disable integrations.
+ */
+function roomify_integrations_form_submit(&$form, &$form_state) {
+  $values = $form_state['values'];
+
+  if (isset($values['roomify_integration_zopim'])) {
+    if ($values['roomify_integration_zopim'] == 1) {
+      if (!module_exists('zopim')) {
+        module_enable(array('zopim'));
+      }
+    }
+    else {
+      if (module_exists('zopim')) {
+        module_disable(array('zopim'));
+      }
+    }
+    menu_rebuild();
+  }
+}
+
+/**
+ * Form "Manage Roomify Integrations".
+ */
+function roomify_manage_integrations_form($form, &$form_state) {
+  $module_path = drupal_get_path('module', 'roomify_integrations');
 
   $form['message'] = array(
     '#markup' => '<div class="message"><h2>' . t('Manage Roomify Integrations') . '</h2></div>',
   );
+  $form['#attached']['css'] = array($module_path . '/css/roomify_integrations.css');
 
-  $form['zopim'] = array(
-    '#markup' => '<div class="zopim-integration">' . l($zopim_image . '<h3>' . t('Zopim Chat') . '</h3>' . t('Talk to your customers in real-time using a live chat.'), $zopim_path, array('html' => TRUE)) . '</div>',
-  );
+  if (variable_get('roomify_integration_zopim', 0) == 1) {
+    $zopim_path = '/admin/config/system/zopim';
+    $zopim_image = theme_image(array('path' => $module_path . '/images/zopim.png', 'attributes' => ''));
+
+    $form['zopim'] = array(
+      '#markup' => '<div class="zopim-integration">' . l($zopim_image . '<h3>' . t('Zopim Chat') . '</h3>' . t('Talk to your customers in real-time using a live chat.'), $zopim_path, array('html' => TRUE)) . '</div>'
+    );
+  }
 
   return $form;
 }

--- a/modules/roomify/roomify_landing_page/roomify_landing_page.info
+++ b/modules/roomify/roomify_landing_page/roomify_landing_page.info
@@ -5,7 +5,6 @@ package = Roomify
 version = 7.x-1.0
 dependencies[] = classy_paragraphs
 dependencies[] = ctools
-dependencies[] = editablefields
 dependencies[] = entity
 dependencies[] = entity_background_color
 dependencies[] = entity_background_image

--- a/modules/roomify/roomify_listing/roomify_listing.fields.inc
+++ b/modules/roomify/roomify_listing/roomify_listing.fields.inc
@@ -2645,43 +2645,46 @@ function roomify_listing_create_standard_type_fields($type_bundle) {
   }
 
   if (field_read_instance('bat_type', 'field_st_allow_instant_bookings', $type_bundle) === FALSE) {
-    $field_instances['bat_type-standard_type-field_st_allow_instant_bookings'] = array(
-      'bundle' => $type_bundle,
-      'default_value' => array(
-        0 => array(
-          'value' => 1,
-        ),
-      ),
-      'description' => 'Enabling instant bookings means that users will be able to book and pay immediately. Make sure to setup a suitable payment method.',
-      'display' => array(
-        'default' => array(
-          'label' => 'above',
-          'module' => 'list',
-          'settings' => array(
-            'conditions' => array(),
+    if ($type_bundle == 'room') {
+      // Add the instant bookings only for rooms.
+      $field_instances['bat_type-standard_type-field_st_allow_instant_bookings'] = array(
+        'bundle' => $type_bundle,
+        'default_value' => array(
+          0 => array(
+            'value' => 1,
           ),
-          'type' => 'list_default',
-          'weight' => 49,
         ),
-      ),
-      'entity_type' => 'bat_type',
-      'field_name' => 'field_st_allow_instant_bookings',
-      'label' => 'Allow instant bookings',
-      'required' => 0,
-      'settings' => array(
-        'entity_translation_sync' => FALSE,
-        'user_register_form' => FALSE,
-      ),
-      'widget' => array(
-        'active' => 1,
-        'module' => 'options',
+        'description' => 'Enabling instant bookings means that users will be able to book and pay immediately. Make sure to setup a suitable payment method.',
+        'display' => array(
+          'default' => array(
+            'label' => 'above',
+            'module' => 'list',
+            'settings' => array(
+              'conditions' => array(),
+            ),
+            'type' => 'list_default',
+            'weight' => 49,
+          ),
+        ),
+        'entity_type' => 'bat_type',
+        'field_name' => 'field_st_allow_instant_bookings',
+        'label' => 'Allow instant bookings',
+        'required' => 0,
         'settings' => array(
-          'display_label' => 1,
+          'entity_translation_sync' => FALSE,
+          'user_register_form' => FALSE,
         ),
-        'type' => 'options_onoff',
-        'weight' => 22,
-      ),
-    );
+        'widget' => array(
+          'active' => 1,
+          'module' => 'options',
+          'settings' => array(
+            'display_label' => 1,
+          ),
+          'type' => 'options_onoff',
+          'weight' => 22,
+        ),
+      );
+    }
   }
 
   if (field_read_instance('bat_type', 'field_st_gallery', $type_bundle) === FALSE) {
@@ -3019,7 +3022,6 @@ function roomify_listing_create_standard_type_fields($type_bundle) {
     $field_group->children = array(
       0 => 'field_st_default_price',
       1 => 'field_st_default_availability',
-      2 => 'field_st_allow_instant_bookings',
       3 => 'field_st_rates_for_person',
       4 => 'field_rates_ranges',
     );
@@ -3032,6 +3034,11 @@ function roomify_listing_create_standard_type_fields($type_bundle) {
         'required_fields' => 1,
       ),
     );
+
+    // Add the instant bookings field if the type is a room.
+    if ($type_bundle == 'room') {
+      $field_group->children[2] = 'field_st_allow_instant_bookings';
+    }
     $field_groups['group_pricing_availability|bat_type|standard_type|form'] = $field_group;
   }
 

--- a/modules/roomify/roomify_listing/roomify_listing.install
+++ b/modules/roomify/roomify_listing/roomify_listing.install
@@ -1142,3 +1142,19 @@ function roomify_listing_update_7024() {
   variable_set('metatag_enable_roomify_property__casa_property', 1);
   variable_set('metatag_enable_roomify_property__locanda_property', 1);
 }
+
+/**
+ * Remove instant booking field for Home types.
+ */
+function roomify_listing_update_7025() {
+  $instance_info = field_read_instance('bat_type', 'field_st_allow_instant_bookings', 'home');
+  field_delete_instance($instance_info);
+
+  // Remove the field from the fieldgroup.
+  $field_group = field_group_load_field_group('group_pricing_availability', 'bat_type', 'home', 'form');
+  foreach ($field_group->children as $key => $value) {
+    if ($value == 'field_st_allow_instant_bookings') {
+      unset($field_group->children[$key]);
+    }
+  }
+}

--- a/modules/roomify/roomify_listing/views/roomify_listing_handler_type_book_this_field.inc
+++ b/modules/roomify/roomify_listing/views/roomify_listing_handler_type_book_this_field.inc
@@ -25,7 +25,11 @@ class roomify_listing_handler_type_book_this_field extends bat_type_handler_link
   public function render($values) {
     $type = bat_type_load($values->{$this->aliases['type_id']});
 
-    $text = !empty($this->options['text']) ? $this->options['text'] : t('Book');
+    // Check if the room may be booked.
+    $instant_booking = field_get_items('bat_type', $type, 'field_st_allow_instant_bookings');
+    $button_text = $instant_booking[0]['value'] ? t('Book Now') : t('Make Enquiry');
+
+    $text = !empty($this->options['text']) ? $this->options['text'] : $button_text;
     $date_format = variable_get('bat_daily_date_format', 'Y-m-d');
 
     $property = roomify_property_load($type->field_st_property_reference[LANGUAGE_NONE][0]['target_id']);

--- a/modules/roomify/roomify_listing_availability_search_block/roomify_listing_availability_search_block.module
+++ b/modules/roomify/roomify_listing_availability_search_block/roomify_listing_availability_search_block.module
@@ -246,6 +246,7 @@ function roomify_listing_search_block_form() {
     '#suffix' => '</div>',
     '#type' => 'submit',
     '#value' => $button_text,
+    '#attributes' => array('class' => array('btn-danger')),
   );
 
   return $form;
@@ -708,6 +709,7 @@ function bat_type_search_availability_form() {
     '#prefix' => '<div class="bat-type-availability-search-submit">',
     '#suffix' => '</div>',
     '#value' => t('Search'),
+    '#attributes' => array('class' => array('btn-default btn-danger')),
   );
 
   return $form;

--- a/modules/roomify/roomify_system/roomify_system.install
+++ b/modules/roomify/roomify_system/roomify_system.install
@@ -572,3 +572,12 @@ function roomify_system_update_7032() {
 function roomify_system_update_7033() {
   module_enable(array('roomify_integrations'));
 }
+
+/**
+ * Remove Editablefields.
+ */
+function roomify_system_update_7034() {
+  db_delete('system')
+    ->condition('name', 'editablefields')
+    ->execute();
+}

--- a/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
+++ b/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
@@ -3253,8 +3253,8 @@ function roomify_travel_theme_default_page_manager_handlers() {
           'settings' => array(
             'description' => 'Locanda or Casa',
             'php' => '$product = variable_get(\'roomify_accommodation_example_content\', \'\');
-  if ($product == \'b_and_b\' || $product == \'vacation_rental\')
-          return TRUE;',
+    if ($product == \'b_and_b\' || $product == \'vacation_rental\')
+            return TRUE;',
           ),
           'not' => FALSE,
         ),
@@ -3263,7 +3263,7 @@ function roomify_travel_theme_default_page_manager_handlers() {
     ),
   );
   $display = new panels_display();
-  $display->layout = 'bootstrap_locanda_page';
+  $display->layout = 'bootstrap_one_column';
   $display->layout_settings = array();
   $display->panel_settings = array(
     'style_settings' => array(
@@ -3311,192 +3311,12 @@ function roomify_travel_theme_default_page_manager_handlers() {
   $display->title = '%type_id:name';
   $display->uuid = '2d69b058-2e08-4ef6-afdb-fbcb4023c51d';
   $display->storage_type = 'page_manager';
-  $display->storage_id = '';
+  $display->storage_id = 'page_listings__locanda-travel';
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();
-  $pane->pid = 'new-0433d235-259a-4cd7-933d-5703a8ab2950';
-  $pane->panel = 'bottom-left';
-  $pane->type = 'views_panes';
-  $pane->subtype = 'property_travel-panel_pane_1';
-  $pane->shown = TRUE;
-  $pane->access = array(
-    'plugins' => array(
-      0 => array(
-        'name' => 'entity_bundle:roomify_property',
-        'settings' => array(
-          'type' => array(
-            'locanda_property' => 'locanda_property',
-          ),
-        ),
-        'context' => 'argument_entity_id:roomify_property_1',
-        'not' => FALSE,
-      ),
-    ),
-  );
-  $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => '',
-    'override_title_heading' => 'h2',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_id' => 'property-types',
-    'css_class' => '',
-  );
-  $pane->extras = array();
-  $pane->position = 0;
-  $pane->locks = array();
-  $pane->uuid = '0433d235-259a-4cd7-933d-5703a8ab2950';
-  $display->content['new-0433d235-259a-4cd7-933d-5703a8ab2950'] = $pane;
-  $display->panels['bottom-left'][0] = 'new-0433d235-259a-4cd7-933d-5703a8ab2950';
-  $pane = new stdClass();
-  $pane->pid = 'new-3d8b4518-b00c-466a-8af4-7c562323b943';
-  $pane->panel = 'bottom-left';
-  $pane->type = 'entity_field';
-  $pane->subtype = 'roomify_property:field_sp_description';
-  $pane->shown = TRUE;
-  $pane->access = array(
-    'plugins' => array(
-      0 => array(
-        'name' => 'entity_bundle:roomify_property',
-        'settings' => array(
-          'type' => array(
-            'casa_property' => 'casa_property',
-          ),
-        ),
-        'context' => 'argument_entity_id:roomify_property_1',
-        'not' => FALSE,
-      ),
-    ),
-  );
-  $pane->configuration = array(
-    'label' => 'title',
-    'formatter' => 'text_default',
-    'delta_limit' => 0,
-    'delta_offset' => '0',
-    'delta_reversed' => FALSE,
-    'formatter_settings' => array(),
-    'context' => 'argument_entity_id:roomify_property_1',
-    'override_title' => 1,
-    'override_title_text' => 'Overview',
-    'override_title_heading' => 'h3',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_id' => '',
-    'css_class' => 'casa-property-description',
-  );
-  $pane->extras = array();
-  $pane->position = 1;
-  $pane->locks = array();
-  $pane->uuid = '3d8b4518-b00c-466a-8af4-7c562323b943';
-  $display->content['new-3d8b4518-b00c-466a-8af4-7c562323b943'] = $pane;
-  $display->panels['bottom-left'][1] = 'new-3d8b4518-b00c-466a-8af4-7c562323b943';
-  $pane = new stdClass();
-  $pane->pid = 'new-4026878e-a350-4dc5-ba8a-8d11b6d248c7';
-  $pane->panel = 'bottom-right';
-  $pane->type = 'entity_field';
-  $pane->subtype = 'roomify_property:field_sp_policies';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'label' => 'title',
-    'formatter' => 'text_default',
-    'delta_limit' => 0,
-    'delta_offset' => '0',
-    'delta_reversed' => FALSE,
-    'formatter_settings' => array(),
-    'context' => 'argument_entity_id:roomify_property_1',
-    'override_title' => 1,
-    'override_title_text' => '<span id="property-policies-tab"></span>Polices',
-    'override_title_heading' => 'h3',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_id' => '',
-    'css_class' => '',
-  );
-  $pane->extras = array();
-  $pane->position = 0;
-  $pane->locks = array();
-  $pane->uuid = '4026878e-a350-4dc5-ba8a-8d11b6d248c7';
-  $display->content['new-4026878e-a350-4dc5-ba8a-8d11b6d248c7'] = $pane;
-  $display->panels['bottom-right'][0] = 'new-4026878e-a350-4dc5-ba8a-8d11b6d248c7';
-  $pane = new stdClass();
-  $pane->pid = 'new-f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75';
-  $pane->panel = 'bottom-right';
-  $pane->type = 'entity_field';
-  $pane->subtype = 'roomify_property:field_sp_amenities';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'label' => 'title',
-    'formatter' => 'taxonomy_term_reference_plain',
-    'delta_limit' => '0',
-    'delta_offset' => '0',
-    'delta_reversed' => 0,
-    'formatter_settings' => array(),
-    'context' => 'argument_entity_id:roomify_property_1',
-    'override_title' => 1,
-    'override_title_text' => '<span id="property-amenities-tab"></span>Amenities',
-    'override_title_heading' => 'h3',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_id' => '',
-    'css_class' => '',
-  );
-  $pane->extras = array();
-  $pane->position = 1;
-  $pane->locks = array();
-  $pane->uuid = 'f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75';
-  $display->content['new-f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75'] = $pane;
-  $display->panels['bottom-right'][1] = 'new-f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75';
-  $pane = new stdClass();
-  $pane->pid = 'new-824392b0-c5d4-4ed7-ab57-b00e404fb51e';
-  $pane->panel = 'bottom-right';
-  $pane->type = 'panels_mini';
-  $pane->subtype = 'property_location';
-  $pane->shown = TRUE;
-  $pane->access = array();
-  $pane->configuration = array(
-    'context' => array(
-      0 => 'argument_entity_id:roomify_property_1',
-    ),
-    'override_title' => 1,
-    'override_title_text' => '<span id="property-location-tab"></span>Location',
-    'override_title_heading' => 'h3',
-  );
-  $pane->cache = array();
-  $pane->style = array(
-    'settings' => NULL,
-  );
-  $pane->css = array(
-    'css_id' => '',
-    'css_class' => '',
-  );
-  $pane->extras = array();
-  $pane->position = 2;
-  $pane->locks = array();
-  $pane->uuid = '824392b0-c5d4-4ed7-ab57-b00e404fb51e';
-  $display->content['new-824392b0-c5d4-4ed7-ab57-b00e404fb51e'] = $pane;
-  $display->panels['bottom-right'][2] = 'new-824392b0-c5d4-4ed7-ab57-b00e404fb51e';
-  $pane = new stdClass();
   $pane->pid = 'new-e01ffd75-ddef-44c3-b1f6-12ecf4700622';
-  $pane->panel = 'bottom-right';
+  $pane->panel = 'bottom';
   $pane->type = 'entity_field';
   $pane->subtype = 'roomify_property:field_sp_description';
   $pane->shown = TRUE;
@@ -3505,9 +3325,7 @@ function roomify_travel_theme_default_page_manager_handlers() {
       0 => array(
         'name' => 'entity_bundle:roomify_property',
         'settings' => array(
-          'type' => array(
-            'locanda_property' => 'locanda_property',
-          ),
+          'type' => array(),
         ),
         'context' => 'argument_entity_id:roomify_property_1',
         'not' => FALSE,
@@ -3535,11 +3353,106 @@ function roomify_travel_theme_default_page_manager_handlers() {
     'css_class' => '',
   );
   $pane->extras = array();
-  $pane->position = 3;
+  $pane->position = 0;
   $pane->locks = array();
   $pane->uuid = 'e01ffd75-ddef-44c3-b1f6-12ecf4700622';
   $display->content['new-e01ffd75-ddef-44c3-b1f6-12ecf4700622'] = $pane;
-  $display->panels['bottom-right'][3] = 'new-e01ffd75-ddef-44c3-b1f6-12ecf4700622';
+  $display->panels['bottom'][0] = 'new-e01ffd75-ddef-44c3-b1f6-12ecf4700622';
+  $pane = new stdClass();
+  $pane->pid = 'new-824392b0-c5d4-4ed7-ab57-b00e404fb51e';
+  $pane->panel = 'bottom';
+  $pane->type = 'panels_mini';
+  $pane->subtype = 'property_location';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'context' => array(
+      0 => 'argument_entity_id:roomify_property_1',
+    ),
+    'override_title' => 1,
+    'override_title_text' => '<span id="property-location-tab"></span>Location',
+    'override_title_heading' => 'h3',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => '',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 1;
+  $pane->locks = array();
+  $pane->uuid = '824392b0-c5d4-4ed7-ab57-b00e404fb51e';
+  $display->content['new-824392b0-c5d4-4ed7-ab57-b00e404fb51e'] = $pane;
+  $display->panels['bottom'][1] = 'new-824392b0-c5d4-4ed7-ab57-b00e404fb51e';
+  $pane = new stdClass();
+  $pane->pid = 'new-f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75';
+  $pane->panel = 'bottom';
+  $pane->type = 'entity_field';
+  $pane->subtype = 'roomify_property:field_sp_amenities';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'label' => 'title',
+    'formatter' => 'taxonomy_term_reference_plain',
+    'delta_limit' => '0',
+    'delta_offset' => '0',
+    'delta_reversed' => 0,
+    'formatter_settings' => array(),
+    'context' => 'argument_entity_id:roomify_property_1',
+    'override_title' => 1,
+    'override_title_text' => '<span id="property-amenities-tab"></span>Amenities',
+    'override_title_heading' => 'h3',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => '',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 2;
+  $pane->locks = array();
+  $pane->uuid = 'f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75';
+  $display->content['new-f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75'] = $pane;
+  $display->panels['bottom'][2] = 'new-f4c87a0f-8a2a-4a84-be06-b0fe7bf33e75';
+  $pane = new stdClass();
+  $pane->pid = 'new-4026878e-a350-4dc5-ba8a-8d11b6d248c7';
+  $pane->panel = 'bottom';
+  $pane->type = 'entity_field';
+  $pane->subtype = 'roomify_property:field_sp_policies';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array(
+    'label' => 'title',
+    'formatter' => 'text_default',
+    'delta_limit' => 0,
+    'delta_offset' => '0',
+    'delta_reversed' => FALSE,
+    'formatter_settings' => array(),
+    'context' => 'argument_entity_id:roomify_property_1',
+    'override_title' => 1,
+    'override_title_text' => '<span id="property-policies-tab"></span>Polices',
+    'override_title_heading' => 'h3',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => '',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 3;
+  $pane->locks = array();
+  $pane->uuid = '4026878e-a350-4dc5-ba8a-8d11b6d248c7';
+  $display->content['new-4026878e-a350-4dc5-ba8a-8d11b6d248c7'] = $pane;
+  $display->panels['bottom'][3] = 'new-4026878e-a350-4dc5-ba8a-8d11b6d248c7';
   $pane = new stdClass();
   $pane->pid = 'new-57121337-eaf4-4f12-9d69-9746f2f6d022';
   $pane->panel = 'middle';
@@ -3615,6 +3528,45 @@ function roomify_travel_theme_default_page_manager_handlers() {
   $pane->uuid = '6b1b6374-7759-470e-8cc9-9c34b7ae881c';
   $display->content['new-6b1b6374-7759-470e-8cc9-9c34b7ae881c'] = $pane;
   $display->panels['middle'][2] = 'new-6b1b6374-7759-470e-8cc9-9c34b7ae881c';
+  $pane = new stdClass();
+  $pane->pid = 'new-0433d235-259a-4cd7-933d-5703a8ab2950';
+  $pane->panel = 'middle';
+  $pane->type = 'views_panes';
+  $pane->subtype = 'property_travel-panel_pane_1';
+  $pane->shown = TRUE;
+  $pane->access = array(
+    'plugins' => array(
+      0 => array(
+        'name' => 'entity_bundle:roomify_property',
+        'settings' => array(
+          'type' => array(
+            'locanda_property' => 'locanda_property',
+          ),
+        ),
+        'context' => 'argument_entity_id:roomify_property_1',
+        'not' => FALSE,
+      ),
+    ),
+  );
+  $pane->configuration = array(
+    'override_title' => 1,
+    'override_title_text' => '',
+    'override_title_heading' => 'h2',
+  );
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array(
+    'css_id' => 'property-types',
+    'css_class' => '',
+  );
+  $pane->extras = array();
+  $pane->position = 3;
+  $pane->locks = array();
+  $pane->uuid = '0433d235-259a-4cd7-933d-5703a8ab2950';
+  $display->content['new-0433d235-259a-4cd7-933d-5703a8ab2950'] = $pane;
+  $display->panels['middle'][3] = 'new-0433d235-259a-4cd7-933d-5703a8ab2950';
   $pane = new stdClass();
   $pane->pid = 'new-681acaee-a6c3-4fde-a101-3ae65b4b2777';
   $pane->panel = 'top';

--- a/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
+++ b/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
@@ -3177,7 +3177,7 @@ function roomify_travel_theme_default_page_manager_handlers() {
   $pane->configuration = array(
     'admin_title' => 'Add Blogposts',
     'title' => '',
-    'body' => '<p><a class="roomify-add-blog-post-link roomify-add-button" href="/node/add/blog">Add Blogpost</a></p>',
+    'body' => '<p><a class="roomify-add-blog-post-link roomify-add-button btn btn-default" href="/node/add/blog">Add Blogpost</a></p>',
     'format' => 'filtered_text',
     'substitute' => 1,
   );

--- a/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
+++ b/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
@@ -1293,7 +1293,7 @@ function roomify_travel_theme_default_page_manager_handlers() {
     ),
   );
   $display->cache = array();
-  $display->title = '';
+  $display->title = '%node:title_field';
   $display->uuid = 'bdfbe48f-f065-4ea6-9330-0aca5c08a60f';
   $display->storage_type = 'page_manager';
   $display->storage_id = 'node_view__blogpost-travel';
@@ -1740,7 +1740,7 @@ function roomify_travel_theme_default_page_manager_handlers() {
     ),
   );
   $display->cache = array();
-  $display->title = '';
+  $display->title = '%node:title_field';
   $display->uuid = 'af415ea7-94db-4ad7-8a09-f539e31d845e';
   $display->storage_type = 'page_manager';
   $display->storage_id = 'node_view__panel_context_7ddeeb25-0c6c-4a38-8df4-e4a2eb636bcd';
@@ -2039,10 +2039,10 @@ function roomify_travel_theme_default_page_manager_handlers() {
     ),
   );
   $display->cache = array();
-  $display->title = '';
+  $display->title = '%node:title_field';
   $display->uuid = '9ef84618-1857-465c-a31a-7230c09fde85';
   $display->storage_type = 'page_manager';
-  $display->storage_id = 'node_view__location';
+  $display->storage_id = 'node_view__location-travel';
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();

--- a/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
+++ b/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
@@ -850,6 +850,9 @@ body #sidebar-wrapper .close-sidebar {
   width: 100%;
   padding-bottom: 10px;
 }
+body #sidebar-wrapper .close-sidebar:after {
+  display: none;
+}
 body #sidebar-wrapper #close-sidebar-icon {
   background: url('../images/close.png') center center no-repeat;
   margin-right: 20px;
@@ -874,10 +877,24 @@ body .sidebar-nav a {
 }
 body .sidebar-nav .panel-pane {
   display: inline-block;
+  margin-bottom: 10px;
   width: 94%;
-  margin-bottom: 30px;
-  border-bottom: 1px solid #03A9F4;
   padding-bottom: 30px;
+  width: 300px;
+}
+body .sidebar-nav .panel-pane:after {
+  content: "";
+  width: 100px;
+  text-align: center;
+  height: 3px;
+  border-radius: 50px;
+  display: table;
+  margin: 0 auto;
+  background: #696969;
+  margin-top: 35px;
+}
+body .sidebar-nav .panel-pane:last-child:after {
+  display: none;
 }
 body .sidebar-nav .panel-pane .pane-title {
   border-bottom: 0;
@@ -885,9 +902,8 @@ body .sidebar-nav .panel-pane .pane-title {
   width: 100%;
   color: white;
   font-weight: 600;
-  padding: 5px 10px;
+  padding: 5px 15px;
   font-size: 22px;
-  text-align: center;
 }
 body .sidebar-nav .pane-roomify-sidebar-user-menu .pane-title {
   margin-bottom: 5px;
@@ -965,7 +981,7 @@ body .sidebar-nav .pane-commerce-cart-cart .line-item-quantity {
   display: none;
 }
 body .sidebar-nav .pane-commerce-cart-cart .glyphicon {
-  font-size: 20px;
+  font-size: 18px;
   margin-right: 4px;
   color: #03A9F4;
   position: relative;
@@ -1002,15 +1018,16 @@ body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title {
   font-weight: 600;
   border-bottom: 0;
   font-size: 22px;
-  text-align: center;
   width: 100%;
 }
 body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .glyphicon {
   display: inline-block;
-  font-size: 20px;
+  font-size: 18px;
   margin-right: 6px;
   z-index: 99;
   color: #03A9F4;
+  top: 2px;
+  right: 4px;
 }
 body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a {
   color: white;
@@ -1064,13 +1081,14 @@ body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title {
   color: white;
   font-weight: 600;
   font-size: 22px;
-  text-align: center;
+  padding: 5px 15px;
+  text-align: left;
   border-bottom: 0;
   width: 100%;
 }
 body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .glyphicon {
   display: inline-block;
-  font-size: 20px;
+  font-size: 18px;
   margin-right: 6px;
   z-index: 99;
   color: #03A9F4;
@@ -1110,12 +1128,12 @@ body .sidebar-nav .pane-my-stays-panel-pane-1 {
 body .sidebar-nav .pane-my-stays-panel-pane-1 .pane-title {
   margin-bottom: 5px;
   font-weight: 600;
-  padding: 5px 10px;
+  padding: 5px 15px;
+  text-align: left;
   font-size: 22px;
   float: left;
   border: 0;
   color: white;
-  text-align: center;
 }
 body .sidebar-nav .pane-my-stays-panel-pane-1 .view-my-stays .views-row {
   display: inline-block;
@@ -3262,6 +3280,9 @@ body .ui-widget table thead th a {
 html,
 body {
   background-color: #fdfdfd !important;
+}
+body {
+  font: 15px/1.6em 'Lato', sans-serif !important;
 }
 body #console.roomify-admin-messages,
 body #page {

--- a/themes/roomify/roomify_adminimal_theme/less/components/sidebar-menu.less
+++ b/themes/roomify/roomify_adminimal_theme/less/components/sidebar-menu.less
@@ -28,6 +28,9 @@ body {
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px;
+      &:after {
+        display: none;
+      }
     }
     #close-sidebar-icon {
       background: url('../images/close.png') center center no-repeat;
@@ -53,22 +56,38 @@ body {
     }
     .panel-pane {
       display: inline-block;
+      margin-bottom: 10px;
       width: 94%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
       padding-bottom: 30px;
+      width: 300px;
+      &:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px;
+      }
+      &:last-child {
+        &:after {
+          display: none;
+        }
+      }
       .pane-title {
         border-bottom: 0;
         text-align: left;
         width: 100%;
         color: white;
         font-weight: 600;
-        padding: 5px 10px;
+        padding: 5px 15px;
         font-size: 22px;
-        text-align: center;
       }
     }
     .pane-roomify-sidebar-user-menu {
+
       .pane-title {
         margin-bottom: 5px;
         font-size: 22px;
@@ -150,7 +169,7 @@ body {
         display: none;
       }
       .glyphicon {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -193,14 +212,15 @@ body {
         font-weight: 600;
         border-bottom: 0;
         font-size: 22px;
-        text-align: center;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
+          top: 2px;
+          right: 4px;
         }
         a {
           color: white;
@@ -257,12 +277,13 @@ body {
         color: white;
         font-weight: 600;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
@@ -308,12 +329,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 600;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
         color: white;
-        text-align: center;
       }
       .view-my-stays {
         .views-row {
@@ -349,8 +370,6 @@ body {
       }
     }
   }
-
-
   &.toggled {
     padding-right: 350px;
     margin-left: -350px;

--- a/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
+++ b/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
@@ -91,6 +91,7 @@ body {
   //}
 }
 body {
+  font: 15px/1.6em 'Lato', sans-serif !important;
   #console.roomify-admin-messages,
   #page {
     margin-bottom: 40px;

--- a/themes/roomify/roomify_bootstrap/assets/css/style.css
+++ b/themes/roomify/roomify_bootstrap/assets/css/style.css
@@ -6705,7 +6705,8 @@ body.roomify-notification .roomify-sidebar-link {
     font-size: 30px; } }
 
 .roomify-language-switcher {
-  position: relative; }
+  position: relative;
+  background: #000000; }
   .roomify-language-switcher .language-switcher-locale-session,
   .roomify-language-switcher .language-switcher-locale-url {
     right: 15px;
@@ -6722,7 +6723,7 @@ body.roomify-notification .roomify-sidebar-link {
       margin-left: 15px; }
       .roomify-language-switcher .language-switcher-locale-session li a,
       .roomify-language-switcher .language-switcher-locale-url li a {
-        color: #FFFFFF; }
+        color: #FFFFFF !important; }
         .roomify-language-switcher .language-switcher-locale-session li a img,
         .roomify-language-switcher .language-switcher-locale-url li a img {
           float: left;

--- a/themes/roomify/roomify_bootstrap/assets/css/style.css
+++ b/themes/roomify/roomify_bootstrap/assets/css/style.css
@@ -6708,22 +6708,29 @@ body.roomify-notification .roomify-sidebar-link {
   position: relative; }
   .roomify-language-switcher .language-switcher-locale-session,
   .roomify-language-switcher .language-switcher-locale-url {
-    position: absolute;
     right: 15px;
     z-index: 15;
-    margin-top: 5px; }
+    display: inline-block;
+    position: relative;
+    top: 8px;
+    text-align: right;
+    width: 100%; }
     .roomify-language-switcher .language-switcher-locale-session li,
     .roomify-language-switcher .language-switcher-locale-url li {
       display: inline-block;
-      float: left;
-      margin-left: 10px; }
+      float: right;
+      margin-left: 15px; }
       .roomify-language-switcher .language-switcher-locale-session li a,
       .roomify-language-switcher .language-switcher-locale-url li a {
-        color: #4A4A4A; }
+        color: #FFFFFF; }
+        .roomify-language-switcher .language-switcher-locale-session li a img,
+        .roomify-language-switcher .language-switcher-locale-url li a img {
+          float: left;
+          margin-right: 5px;
+          margin-top: 4px; }
       .roomify-language-switcher .language-switcher-locale-session li.active,
       .roomify-language-switcher .language-switcher-locale-url li.active {
-        text-decoration: underline;
-        font-weight: bold; }
+        text-decoration: underline; }
 
 body.home #content {
   padding: 0; }
@@ -6838,10 +6845,10 @@ body.home #content {
 
 body {
   padding-right: 0;
-  -webkit-transition: 70ms all linear;
-  -moz-transition: 70ms all linear;
-  -ms-transition: 70ms all linear;
-  -o-transition: 70ms all linear; }
+  -webkit-transition: 60ms all linear;
+  -moz-transition: 60ms all linear;
+  -ms-transition: 60ms all linear;
+  -o-transition: 60ms all linear; }
   body #sidebar-wrapper {
     z-index: 1000;
     position: fixed;
@@ -6852,19 +6859,17 @@ body {
     overflow-y: auto;
     background: #000;
     overflow-x: hidden;
-    -webkit-transition: 70ms all linear;
-    -moz-transition: 70ms all linear;
-    -ms-transition: 70ms all linear;
-    -o-transition: 70ms all linear;
-    -webkit-transition: 2ms width linear;
-    -moz-transition: 2ms width linear;
-    -ms-transition: 2ms width linear;
-    -o-transition: 2ms width linear; }
+    -webkit-transition: 60ms all linear;
+    -moz-transition: 60ms all linear;
+    -ms-transition: 60ms all linear;
+    -o-transition: 60ms all linear; }
     body #sidebar-wrapper .close-sidebar {
       border-bottom: 0;
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px; }
+      body #sidebar-wrapper .close-sidebar:after {
+        display: none; }
     body #sidebar-wrapper #close-sidebar-icon {
       background: url("../images/close.png") center center no-repeat;
       margin-right: 20px;
@@ -6887,20 +6892,29 @@ body {
     body .sidebar-nav .panel-pane {
       display: inline-block;
       width: 100%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
-      padding-bottom: 30px; }
-      body .sidebar-nav .panel-pane:last-child {
-        border-bottom: none; }
+      margin-bottom: 10px;
+      padding-bottom: 30px;
+      min-width: 320px; }
+      body .sidebar-nav .panel-pane:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px; }
+      body .sidebar-nav .panel-pane:last-child:after {
+        display: none; }
       body .sidebar-nav .panel-pane .pane-title {
         border-bottom: 0;
         text-align: left;
         width: 100%;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
-        font-size: 22px;
-        text-align: center; }
+        padding: 5px 15px;
+        font-size: 22px; }
     body .sidebar-nav .pane-roomify-sidebar-user-menu .pane-title {
       margin-bottom: 5px;
       font-size: 22px; }
@@ -6998,7 +7012,7 @@ body {
       body .sidebar-nav .pane-commerce-cart-cart .glyphicon, body .sidebar-nav .pane-commerce-cart-cart .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-commerce-cart-cart a::before, body .sidebar-nav .pane-commerce-cart-cart .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before,
       body .sidebar-nav .pane-commerce-cart-cart .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
       .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before, body .sidebar-nav .pane-commerce-cart-cart .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit button::before, .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -7032,16 +7046,17 @@ body {
       font-weight: 400;
       border-bottom: 0;
       font-size: 22px;
-      text-align: center;
       width: 100%; }
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .glyphicon, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a::before, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before,
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
       .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit button::before, .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before {
         display: inline-block;
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 6px;
         z-index: 99;
-        color: #03A9F4; }
+        color: #03A9F4;
+        top: 2px;
+        right: 4px; }
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a {
         color: white; }
         body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a:hover {
@@ -7082,14 +7097,15 @@ body {
         color: white;
         font-weight: 400;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%; }
         body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .glyphicon, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title a::before, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before,
         body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
         .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit button::before, .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4; }
@@ -7122,12 +7138,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
-        color: white;
-        text-align: center; }
+        color: white; }
       body .sidebar-nav .pane-my-stays-panel-pane-1 .view-my-stays .views-row {
         display: inline-block;
         width: 100%;
@@ -7168,7 +7184,9 @@ body {
       padding-right: 300px;
       margin-left: -300px; }
       body.toggled #sidebar-wrapper {
-        width: 300px; } }
+        width: 300px; }
+      body.toggled .sidebar-nav .panel-pane {
+        min-width: 280px; } }
 
 .roomify-sidebar-link a {
   font-size: 15px;
@@ -7187,10 +7205,10 @@ body.toggled #close-sidebar-wrapper {
   background: rgba(0, 0, 0, 0.35);
   height: 100%;
   cursor: pointer;
-  -webkit-transition: 80ms padding linear;
-  -moz-transition: 80ms padding linear;
-  -ms-transition: 80ms padding linear;
-  -o-transition: 80ms padding linear; }
+  -webkit-transition: 60ms all linear;
+  -moz-transition: 60ms all linear;
+  -ms-transition: 60ms all linear;
+  -o-transition: 60ms all linear; }
 
 footer {
   background: #333333;
@@ -8568,9 +8586,9 @@ body.error404 .page-content-center {
     .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-property-types .types {
       display: inline-block;
       width: 100%;
-      overflow-y: scroll;
+      overflow-y: auto;
       margin-top: 10px;
-      max-height: 60%; }
+      max-height: 136px; }
       .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-property-types .types table,
       .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-property-types .types table {
         width: 100%; }
@@ -8686,9 +8704,9 @@ body.error404 .page-content-center {
         .page-availability-search .view-display-id-panel_pane_3 .property-row:hover .featured-image-with-description .property-info .property-types-table .types {
           display: inline-block;
           width: 100%;
-          overflow-y: scroll;
+          overflow-y: auto;
           margin-top: 10px;
-          max-height: 60%; }
+          max-height: 136px; }
           .page-activities-search .view-display-id-panel_pane_3 .property-row:hover .featured-image-with-description .property-info .property-types-table .types table,
           .page-availability-search .view-display-id-panel_pane_3 .property-row:hover .featured-image-with-description .property-info .property-types-table .types table {
             width: 100%; }
@@ -8747,9 +8765,9 @@ body.error404 .page-content-center {
   .page-availability-search .view-display-id-panel_pane_3 .views-field-property-types .types {
     display: inline-block;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-top: 10px;
-    max-height: 60%; }
+    max-height: 136px; }
     .page-activities-search .view-display-id-panel_pane_3 .views-field-property-types .types table,
     .page-availability-search .view-display-id-panel_pane_3 .views-field-property-types .types table {
       width: 100%; }
@@ -8820,9 +8838,9 @@ body.error404 .page-content-center {
   .page-availability-search .view-display-id-panel_pane_3 .views-row .views-field-property-types .types {
     display: inline-block;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-top: 10px;
-    max-height: 60%; }
+    max-height: 136px; }
     .page-activities-search .view-display-id-panel_pane_3 .views-row .views-field-property-types .types table,
     .page-availability-search .view-display-id-panel_pane_3 .views-row .views-field-property-types .types table {
       width: 100%; }
@@ -8867,26 +8885,36 @@ body.error404 .page-content-center {
           margin-left: 2%;
           text-align: left;
           padding-left: 0; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
-  max-width: 250px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
-  font-size: 18px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
-  margin: 5px 0;
-  font-size: 14px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
-  display: inline-block;
-  max-width: 250px;
-  margin: 5px 0; }
-  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img,
-  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
-    width: 100% !important;
-    border-radius: 5px;
-    min-width: 120px; }
+.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup-content-wrapper,
+.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup-content-wrapper {
+  border-radius: 4px; }
+.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup,
+.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup {
+  min-height: 250px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
+    max-width: 170px;
+    margin: 14px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
+    font-size: 16px;
+    color: #000000;
+    text-decoration: underline; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
+    margin: 5px 0;
+    font-size: 13px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
+    display: inline-block;
+    max-width: 250px;
+    margin: 5px 0; }
+    .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img,
+    .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
+      width: 100% !important;
+      border-radius: 2px;
+      min-width: 120px;
+      min-height: 120px; }
 
 #property-bat-activity-facets-availability .form-wrapper,
 #roomify-property-search-block-form .form-wrapper,

--- a/themes/roomify/roomify_bootstrap/assets/sass/page/_availability-search.scss
+++ b/themes/roomify/roomify_bootstrap/assets/sass/page/_availability-search.scss
@@ -117,9 +117,9 @@
         .types {
           display: inline-block;
           width: 100%;
-          overflow-y: scroll;
+          overflow-y: auto;
           margin-top: 10px;
-          max-height: 60%;
+          max-height: 136px;
           table {
             width: 100%;
           }
@@ -237,9 +237,9 @@
               .types {
                 display: inline-block;
                 width: 100%;
-                overflow-y: scroll;
+                overflow-y: auto;
                 margin-top: 10px;
-                max-height: 60%;
+                max-height: 136px;
                 table {
                   width: 100%;
                 }
@@ -303,9 +303,9 @@
       .types {
         display: inline-block;
         width: 100%;
-        overflow-y: scroll;
+        overflow-y: auto;
         margin-top: 10px;
-        max-height: 60%;
+        max-height: 136px;
         table {
           width: 100%;
         }
@@ -378,9 +378,9 @@
         .types {
           display: inline-block;
           width: 100%;
-          overflow-y: scroll;
+          overflow-y: auto;
           margin-top: 10px;
-          max-height: 60%;
+          max-height: 136px;
           table {
             width: 100%;
           }
@@ -434,16 +434,23 @@
   // MAP VIEW
   .view-display-id-panel_pane_2 {
     #leaflet-map {
+      .leaflet-popup-content-wrapper {
+        border-radius: 4px;
+      }
       .leaflet-popup {
+        min-height: 250px;
         .leaflet-popup-content {
-          max-width: 250px;
+          max-width: 170px;
+          margin: 14px;
         }
         a {
-          font-size: 18px;
+          font-size: 16px;
+          color: #000000;
+          text-decoration: underline;
         }
         .roomify-property-short-description {
           margin: 5px 0;
-          font-size: 14px;
+          font-size: 13px;
         }
         .roomify-property-image {
           display: inline-block;
@@ -451,8 +458,9 @@
           margin: 5px 0;
           img {
             width: 100% !important;
-            border-radius: 5px;
+            border-radius: 2px;
             min-width: 120px;
+            min-height: 120px;
           }
         }
       }

--- a/themes/roomify/roomify_bootstrap/assets/sass/regions/_header.scss
+++ b/themes/roomify/roomify_bootstrap/assets/sass/regions/_header.scss
@@ -292,6 +292,7 @@ body.roomify-notification {
 
 .roomify-language-switcher {
   position: relative;
+  background: #000000;
   .language-switcher-locale-session,
   .language-switcher-locale-url {
     right: 15px;
@@ -306,7 +307,7 @@ body.roomify-notification {
       float: right;
       margin-left: 15px;
       a {
-        color: #FFFFFF;
+        color: #FFFFFF !important;
         img {
           float: left;
           margin-right: 5px;

--- a/themes/roomify/roomify_bootstrap/assets/sass/regions/_header.scss
+++ b/themes/roomify/roomify_bootstrap/assets/sass/regions/_header.scss
@@ -294,20 +294,27 @@ body.roomify-notification {
   position: relative;
   .language-switcher-locale-session,
   .language-switcher-locale-url {
-    position: absolute;
     right: 15px;
     z-index: 15;
-    margin-top: 5px;
+    display: inline-block;
+    position: relative;
+    top: 8px;
+    text-align: right;
+    width: 100%;
     li {
       display: inline-block;
-      float: left;
-      margin-left: 10px;
+      float: right;
+      margin-left: 15px;
       a {
-        color: #4A4A4A;
+        color: #FFFFFF;
+        img {
+          float: left;
+          margin-right: 5px;
+          margin-top: 4px;
+        }
       }
       &.active {
         text-decoration: underline;
-        font-weight: bold;
       }
     }
   }

--- a/themes/roomify/roomify_bootstrap/assets/sass/regions/_sidebar-wrapper.scss
+++ b/themes/roomify/roomify_bootstrap/assets/sass/regions/_sidebar-wrapper.scss
@@ -1,7 +1,6 @@
-
 body {
   padding-right: 0;
-  @include transition(70ms all linear);
+  @include transition(60ms all linear);
   #sidebar-wrapper {
     z-index: 1000;
     position: fixed;
@@ -12,13 +11,15 @@ body {
     overflow-y: auto;
     background: #000;
     overflow-x: hidden;
-    @include transition(70ms all linear);
-    @include transition(2ms width linear);
+    @include transition(60ms all linear);
     .close-sidebar {
       border-bottom: 0;
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px;
+      &:after {
+        display: none;
+      }
     }
     #close-sidebar-icon {
       background: url('../images/close.png') center center no-repeat;
@@ -45,11 +46,24 @@ body {
     .panel-pane {
       display: inline-block;
       width: 100%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
+      margin-bottom: 10px;
       padding-bottom: 30px;
+      min-width: 320px;
+      &:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px;
+      }
       &:last-child {
-        border-bottom: none;
+        &:after {
+          display: none;
+        }
       }
       .pane-title {
         border-bottom: 0;
@@ -57,12 +71,12 @@ body {
         width: 100%;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
         font-size: 22px;
-        text-align: center;
       }
     }
     .pane-roomify-sidebar-user-menu {
+
       .pane-title {
         margin-bottom: 5px;
         font-size: 22px;
@@ -184,7 +198,7 @@ body {
         display: none;
       }
       .glyphicon {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -228,14 +242,15 @@ body {
         font-weight: 400;
         border-bottom: 0;
         font-size: 22px;
-        text-align: center;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
+          top: 2px;
+          right: 4px;
         }
         a {
           color: white;
@@ -292,12 +307,13 @@ body {
         color: white;
         font-weight: 400;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
@@ -343,12 +359,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
         color: white;
-        text-align: center;
       }
       .view-my-stays {
         .views-row {
@@ -384,8 +400,6 @@ body {
       }
     }
   }
-
-
   &.toggled {
     padding-right: 350px;
     margin-left: -350px;
@@ -408,6 +422,11 @@ body {
       margin-left: -300px;
       #sidebar-wrapper {
         width: 300px;
+      }
+      .sidebar-nav {
+        .panel-pane {
+          min-width: 280px;
+        }
       }
     }
   }
@@ -436,6 +455,6 @@ body.toggled {
     background: rgba(0, 0, 0, 0.35);
     height: 100%;
     cursor: pointer;
-    @include transition(80ms padding linear);
+    @include transition(60ms all linear);
   }
 }

--- a/themes/roomify/roomify_bootstrap_wide/assets/css/style.css
+++ b/themes/roomify/roomify_bootstrap_wide/assets/css/style.css
@@ -6701,23 +6701,29 @@ body.roomify-notification .roomify-sidebar-link {
 
 .roomify-language-switcher .language-switcher-locale-session,
 .roomify-language-switcher .language-switcher-locale-url {
-  position: absolute;
   right: 15px;
   z-index: 15;
-  margin-top: 5px; }
+  display: inline-block;
+  position: relative;
+  top: 8px;
+  text-align: right;
+  width: 100%; }
   .roomify-language-switcher .language-switcher-locale-session li,
   .roomify-language-switcher .language-switcher-locale-url li {
     display: inline-block;
-    float: left;
-    margin-left: 10px; }
+    float: right;
+    margin-left: 15px; }
     .roomify-language-switcher .language-switcher-locale-session li a,
     .roomify-language-switcher .language-switcher-locale-url li a {
-      color: #CCCCCC;
-      font-weight: 600; }
+      color: #FFFFFF; }
+      .roomify-language-switcher .language-switcher-locale-session li a img,
+      .roomify-language-switcher .language-switcher-locale-url li a img {
+        float: left;
+        margin-right: 5px;
+        margin-top: 4px; }
     .roomify-language-switcher .language-switcher-locale-session li.active,
     .roomify-language-switcher .language-switcher-locale-url li.active {
-      text-decoration: underline;
-      font-weight: bold; }
+      text-decoration: underline; }
 
 body.home #content {
   padding: 0; }
@@ -6832,10 +6838,10 @@ body.home #content {
 
 body {
   padding-right: 0;
-  -webkit-transition: 70ms all linear;
-  -moz-transition: 70ms all linear;
-  -ms-transition: 70ms all linear;
-  -o-transition: 70ms all linear; }
+  -webkit-transition: 60ms all linear;
+  -moz-transition: 60ms all linear;
+  -ms-transition: 60ms all linear;
+  -o-transition: 60ms all linear; }
   body #sidebar-wrapper {
     z-index: 1000;
     position: fixed;
@@ -6846,19 +6852,17 @@ body {
     overflow-y: auto;
     background: #000;
     overflow-x: hidden;
-    -webkit-transition: 70ms all linear;
-    -moz-transition: 70ms all linear;
-    -ms-transition: 70ms all linear;
-    -o-transition: 70ms all linear;
-    -webkit-transition: 2ms width linear;
-    -moz-transition: 2ms width linear;
-    -ms-transition: 2ms width linear;
-    -o-transition: 2ms width linear; }
+    -webkit-transition: 60ms all linear;
+    -moz-transition: 60ms all linear;
+    -ms-transition: 60ms all linear;
+    -o-transition: 60ms all linear; }
     body #sidebar-wrapper .close-sidebar {
       border-bottom: 0;
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px; }
+      body #sidebar-wrapper .close-sidebar:after {
+        display: none; }
     body #sidebar-wrapper #close-sidebar-icon {
       background: url("../images/close.png") center center no-repeat;
       margin-right: 20px;
@@ -6881,20 +6885,29 @@ body {
     body .sidebar-nav .panel-pane {
       display: inline-block;
       width: 100%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
-      padding-bottom: 30px; }
-      body .sidebar-nav .panel-pane:last-child {
-        border-bottom: none; }
+      margin-bottom: 10px;
+      padding-bottom: 30px;
+      min-width: 320px; }
+      body .sidebar-nav .panel-pane:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px; }
+      body .sidebar-nav .panel-pane:last-child:after {
+        display: none; }
       body .sidebar-nav .panel-pane .pane-title {
         border-bottom: 0;
         text-align: left;
         width: 100%;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
-        font-size: 22px;
-        text-align: center; }
+        padding: 5px 15px;
+        font-size: 22px; }
     body .sidebar-nav .pane-roomify-sidebar-user-menu .pane-title {
       margin-bottom: 5px;
       font-size: 22px; }
@@ -6992,7 +7005,7 @@ body {
       body .sidebar-nav .pane-commerce-cart-cart .glyphicon, body .sidebar-nav .pane-commerce-cart-cart .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-commerce-cart-cart a::before, body .sidebar-nav .pane-commerce-cart-cart .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before,
       body .sidebar-nav .pane-commerce-cart-cart .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
       .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before, body .sidebar-nav .pane-commerce-cart-cart .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit button::before, .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -7026,16 +7039,17 @@ body {
       font-weight: 400;
       border-bottom: 0;
       font-size: 22px;
-      text-align: center;
       width: 100%; }
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .glyphicon, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a::before, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before,
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
       .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit button::before, .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before {
         display: inline-block;
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 6px;
         z-index: 99;
-        color: #03A9F4; }
+        color: #03A9F4;
+        top: 2px;
+        right: 4px; }
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a {
         color: white; }
         body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a:hover {
@@ -7076,14 +7090,15 @@ body {
         color: white;
         font-weight: 400;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%; }
         body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .glyphicon, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title a::before, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before,
         body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
         .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit button::before, .page-activity-booking #roomify-activity-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4; }
@@ -7116,12 +7131,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
-        color: white;
-        text-align: center; }
+        color: white; }
       body .sidebar-nav .pane-my-stays-panel-pane-1 .view-my-stays .views-row {
         display: inline-block;
         width: 100%;
@@ -7162,7 +7177,9 @@ body {
       padding-right: 300px;
       margin-left: -300px; }
       body.toggled #sidebar-wrapper {
-        width: 300px; } }
+        width: 300px; }
+      body.toggled .sidebar-nav .panel-pane {
+        min-width: 280px; } }
 
 .roomify-sidebar-link a {
   font-size: 15px;
@@ -7181,10 +7198,10 @@ body.toggled #close-sidebar-wrapper {
   background: rgba(0, 0, 0, 0.35);
   height: 100%;
   cursor: pointer;
-  -webkit-transition: 80ms padding linear;
-  -moz-transition: 80ms padding linear;
-  -ms-transition: 80ms padding linear;
-  -o-transition: 80ms padding linear; }
+  -webkit-transition: 60ms all linear;
+  -moz-transition: 60ms all linear;
+  -ms-transition: 60ms all linear;
+  -o-transition: 60ms all linear; }
 
 footer {
   background: #333333;
@@ -8566,9 +8583,9 @@ body.error404 .page-content-center {
     .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-property-types .types {
       display: inline-block;
       width: 100%;
-      overflow-y: scroll;
+      overflow-y: auto;
       margin-top: 10px;
-      max-height: 60%; }
+      max-height: 136px; }
       .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-property-types .types table,
       .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-property-types .types table {
         width: 100%; }
@@ -8684,9 +8701,9 @@ body.error404 .page-content-center {
         .page-availability-search .view-display-id-panel_pane_3 .property-row:hover .featured-image-with-description .property-info .property-types-table .types {
           display: inline-block;
           width: 100%;
-          overflow-y: scroll;
+          overflow-y: auto;
           margin-top: 10px;
-          max-height: 60%; }
+          max-height: 136px; }
           .page-activities-search .view-display-id-panel_pane_3 .property-row:hover .featured-image-with-description .property-info .property-types-table .types table,
           .page-availability-search .view-display-id-panel_pane_3 .property-row:hover .featured-image-with-description .property-info .property-types-table .types table {
             width: 100%; }
@@ -8745,9 +8762,9 @@ body.error404 .page-content-center {
   .page-availability-search .view-display-id-panel_pane_3 .views-field-property-types .types {
     display: inline-block;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-top: 10px;
-    max-height: 60%; }
+    max-height: 136px; }
     .page-activities-search .view-display-id-panel_pane_3 .views-field-property-types .types table,
     .page-availability-search .view-display-id-panel_pane_3 .views-field-property-types .types table {
       width: 100%; }
@@ -8818,9 +8835,9 @@ body.error404 .page-content-center {
   .page-availability-search .view-display-id-panel_pane_3 .views-row .views-field-property-types .types {
     display: inline-block;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-top: 10px;
-    max-height: 60%; }
+    max-height: 136px; }
     .page-activities-search .view-display-id-panel_pane_3 .views-row .views-field-property-types .types table,
     .page-availability-search .view-display-id-panel_pane_3 .views-row .views-field-property-types .types table {
       width: 100%; }
@@ -8865,26 +8882,36 @@ body.error404 .page-content-center {
           margin-left: 2%;
           text-align: left;
           padding-left: 0; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
-  max-width: 250px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
-  font-size: 18px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
-  margin: 5px 0;
-  font-size: 14px; }
-.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
-.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
-  display: inline-block;
-  max-width: 250px;
-  margin: 5px 0; }
-  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img,
-  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
-    width: 100% !important;
-    border-radius: 5px;
-    min-width: 120px; }
+.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup-content-wrapper,
+.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup-content-wrapper {
+  border-radius: 4px; }
+.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup,
+.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup {
+  min-height: 250px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
+    max-width: 170px;
+    margin: 14px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
+    font-size: 16px;
+    color: #000000;
+    text-decoration: underline; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
+    margin: 5px 0;
+    font-size: 13px; }
+  .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
+  .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
+    display: inline-block;
+    max-width: 250px;
+    margin: 5px 0; }
+    .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img,
+    .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
+      width: 100% !important;
+      border-radius: 2px;
+      min-width: 120px;
+      min-height: 120px; }
 
 #property-bat-activity-facets-availability .form-wrapper,
 #roomify-property-search-block-form .form-wrapper,
@@ -9890,10 +9917,11 @@ body.error404 .page-content-center {
   .view-user-conversations .views-row img {
     border: 2px solid #03a9f4; }
 
-.page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
+.page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
 .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival,
 .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure,
 .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights,
+.page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size,
 .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price {
   position: relative;
   float: left;
@@ -9915,42 +9943,47 @@ body.error404 .page-content-center {
   min-height: 120px;
   background: white; }
   @media (min-width: 768px) {
-    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
+    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights,
+    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price {
       float: left;
       width: 50%; } }
   @media (min-width: 992px) {
-    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
+    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights,
+    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price {
       float: left;
-      width: 25%; } }
+      width: 20%; } }
   @media (max-width: 992px) {
-    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
+    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights,
+    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price {
       border-right: 1px solid #E6E6E6; } }
-  .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price label,
+  .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size label, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price label,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival label,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure label,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights label,
+  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size label,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price label {
     width: 100%;
     text-transform: uppercase;
     text-align: center;
     font-size: 16px;
     margin-top: 10px; }
-  .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price span,
+  .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size span, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price span,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-arrival span,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-departure span,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-nights span,
+  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-group-size span,
   .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price span {
     text-align: center;
     width: 100%;
@@ -9962,6 +9995,16 @@ body.error404 .page-content-center {
 .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price,
 .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price {
   border-right: 1px solid #E6E6E6; }
+  .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price .booking-cost,
+  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price .booking-cost {
+    text-decoration: line-through;
+    margin-top: 0;
+    line-height: 1.4em; }
+  .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price .offer-cost,
+  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-price .offer-cost {
+    color: #FF0000;
+    margin-top: 0;
+    line-height: 1.4em; }
 .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit,
 .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit {
   position: relative;
@@ -10120,7 +10163,18 @@ body.error404 .page-content-center {
       padding-left: 25px; }
     .page-conversation-booking #roomify-accommodation-booking-confirmation-form table .price,
     .page-booking #roomify-accommodation-booking-confirmation-form table .price {
-      text-align: center; }
+      text-align: right; }
+      .page-conversation-booking #roomify-accommodation-booking-confirmation-form table .price .tax,
+      .page-conversation-booking #roomify-accommodation-booking-confirmation-form table .price .booking-cost,
+      .page-booking #roomify-accommodation-booking-confirmation-form table .price .tax,
+      .page-booking #roomify-accommodation-booking-confirmation-form table .price .booking-cost {
+        text-decoration: line-through;
+        margin-right: 10px; }
+      .page-conversation-booking #roomify-accommodation-booking-confirmation-form table .price .offer-tax,
+      .page-conversation-booking #roomify-accommodation-booking-confirmation-form table .price .offer-cost,
+      .page-booking #roomify-accommodation-booking-confirmation-form table .price .offer-tax,
+      .page-booking #roomify-accommodation-booking-confirmation-form table .price .offer-cost {
+        color: #FF0000; }
     .page-conversation-booking #roomify-accommodation-booking-confirmation-form table .bold,
     .page-booking #roomify-accommodation-booking-confirmation-form table .bold {
       font-weight: bold;

--- a/themes/roomify/roomify_bootstrap_wide/assets/css/style.css
+++ b/themes/roomify/roomify_bootstrap_wide/assets/css/style.css
@@ -6699,31 +6699,34 @@ body.roomify-notification .roomify-sidebar-link {
     color: red;
     font-size: 30px; } }
 
-.roomify-language-switcher .language-switcher-locale-session,
-.roomify-language-switcher .language-switcher-locale-url {
-  right: 15px;
-  z-index: 15;
-  display: inline-block;
+.roomify-language-switcher {
   position: relative;
-  top: 8px;
-  text-align: right;
-  width: 100%; }
-  .roomify-language-switcher .language-switcher-locale-session li,
-  .roomify-language-switcher .language-switcher-locale-url li {
+  background: #000000; }
+  .roomify-language-switcher .language-switcher-locale-session,
+  .roomify-language-switcher .language-switcher-locale-url {
+    right: 15px;
+    z-index: 15;
     display: inline-block;
-    float: right;
-    margin-left: 15px; }
-    .roomify-language-switcher .language-switcher-locale-session li a,
-    .roomify-language-switcher .language-switcher-locale-url li a {
-      color: #FFFFFF; }
-      .roomify-language-switcher .language-switcher-locale-session li a img,
-      .roomify-language-switcher .language-switcher-locale-url li a img {
-        float: left;
-        margin-right: 5px;
-        margin-top: 4px; }
-    .roomify-language-switcher .language-switcher-locale-session li.active,
-    .roomify-language-switcher .language-switcher-locale-url li.active {
-      text-decoration: underline; }
+    position: relative;
+    top: 8px;
+    text-align: right;
+    width: 100%; }
+    .roomify-language-switcher .language-switcher-locale-session li,
+    .roomify-language-switcher .language-switcher-locale-url li {
+      display: inline-block;
+      float: right;
+      margin-left: 15px; }
+      .roomify-language-switcher .language-switcher-locale-session li a,
+      .roomify-language-switcher .language-switcher-locale-url li a {
+        color: #FFFFFF !important; }
+        .roomify-language-switcher .language-switcher-locale-session li a img,
+        .roomify-language-switcher .language-switcher-locale-url li a img {
+          float: left;
+          margin-right: 5px;
+          margin-top: 4px; }
+      .roomify-language-switcher .language-switcher-locale-session li.active,
+      .roomify-language-switcher .language-switcher-locale-url li.active {
+        text-decoration: underline; }
 
 body.home #content {
   padding: 0; }

--- a/themes/roomify/roomify_bootstrap_wide/assets/sass/page/_availability-search.scss
+++ b/themes/roomify/roomify_bootstrap_wide/assets/sass/page/_availability-search.scss
@@ -117,9 +117,9 @@
         .types {
           display: inline-block;
           width: 100%;
-          overflow-y: scroll;
+          overflow-y: auto;
           margin-top: 10px;
-          max-height: 60%;
+          max-height: 136px;
           table {
             width: 100%;
           }
@@ -237,9 +237,9 @@
               .types {
                 display: inline-block;
                 width: 100%;
-                overflow-y: scroll;
+                overflow-y: auto;
                 margin-top: 10px;
-                max-height: 60%;
+                max-height: 136px;
                 table {
                   width: 100%;
                 }
@@ -303,9 +303,9 @@
       .types {
         display: inline-block;
         width: 100%;
-        overflow-y: scroll;
+        overflow-y: auto;
         margin-top: 10px;
-        max-height: 60%;
+        max-height: 136px;
         table {
           width: 100%;
         }
@@ -378,9 +378,9 @@
         .types {
           display: inline-block;
           width: 100%;
-          overflow-y: scroll;
+          overflow-y: auto;
           margin-top: 10px;
-          max-height: 60%;
+          max-height: 136px;
           table {
             width: 100%;
           }
@@ -434,16 +434,23 @@
   // MAP VIEW
   .view-display-id-panel_pane_2 {
     #leaflet-map {
+      .leaflet-popup-content-wrapper {
+        border-radius: 4px;
+      }
       .leaflet-popup {
+        min-height: 250px;
         .leaflet-popup-content {
-          max-width: 250px;
+          max-width: 170px;
+          margin: 14px;
         }
         a {
-          font-size: 18px;
+          font-size: 16px;
+          color: #000000;
+          text-decoration: underline;
         }
         .roomify-property-short-description {
           margin: 5px 0;
-          font-size: 14px;
+          font-size: 13px;
         }
         .roomify-property-image {
           display: inline-block;
@@ -451,8 +458,9 @@
           margin: 5px 0;
           img {
             width: 100% !important;
-            border-radius: 5px;
+            border-radius: 2px;
             min-width: 120px;
+            min-height: 120px;
           }
         }
       }

--- a/themes/roomify/roomify_bootstrap_wide/assets/sass/page/_booking.scss
+++ b/themes/roomify/roomify_bootstrap_wide/assets/sass/page/_booking.scss
@@ -6,10 +6,11 @@
       &.current-search-arrival,
       &.current-search-departure,
       &.current-search-nights,
+      &.current-search-group-size,
       &.current-search-price {
         @include make-xs-column(12);
         @include make-sm-column(6);
-        @include make-md-column(3);
+        @include make-md-column(2.4);
         padding: 10px;
         border: 1px solid #E6E6E6;
         border-right: 0px;
@@ -37,6 +38,16 @@
       }
       &.current-search-price {
         border-right: 1px solid #E6E6E6;
+        .booking-cost {
+          text-decoration: line-through;
+          margin-top: 0;
+          line-height: 1.4em;
+        }
+        .offer-cost {
+          color: #FF0000;
+          margin-top: 0;
+          line-height: 1.4em;
+        }
       }
       &.current-search-submit {
         @include make-xs-column(12);
@@ -126,7 +137,16 @@
         padding-left: 25px;
       }
       .price {
-        text-align: center;
+        text-align: right;
+        .tax,
+        .booking-cost {
+          text-decoration: line-through;
+          margin-right: 10px;
+        }
+        .offer-tax,
+        .offer-cost {
+          color: #FF0000;
+        }
       }
       .bold {
         font-weight: bold;

--- a/themes/roomify/roomify_bootstrap_wide/assets/sass/regions/_header.scss
+++ b/themes/roomify/roomify_bootstrap_wide/assets/sass/regions/_header.scss
@@ -289,6 +289,8 @@ body.roomify-notification {
 }
 
 .roomify-language-switcher {
+  position: relative;
+  background: #000000;
   .language-switcher-locale-session,
   .language-switcher-locale-url {
     right: 15px;
@@ -303,7 +305,7 @@ body.roomify-notification {
       float: right;
       margin-left: 15px;
       a {
-        color: #FFFFFF;
+        color: #FFFFFF !important;
         img {
           float: left;
           margin-right: 5px;
@@ -316,4 +318,3 @@ body.roomify-notification {
     }
   }
 }
-    

--- a/themes/roomify/roomify_bootstrap_wide/assets/sass/regions/_header.scss
+++ b/themes/roomify/roomify_bootstrap_wide/assets/sass/regions/_header.scss
@@ -291,21 +291,27 @@ body.roomify-notification {
 .roomify-language-switcher {
   .language-switcher-locale-session,
   .language-switcher-locale-url {
-    position: absolute;
     right: 15px;
     z-index: 15;
-    margin-top: 5px;
+    display: inline-block;
+    position: relative;
+    top: 8px;
+    text-align: right;
+    width: 100%;
     li {
       display: inline-block;
-      float: left;
-      margin-left: 10px;
+      float: right;
+      margin-left: 15px;
       a {
-        color: #CCCCCC;
-        font-weight:600;
+        color: #FFFFFF;
+        img {
+          float: left;
+          margin-right: 5px;
+          margin-top: 4px;
+        }
       }
       &.active {
         text-decoration: underline;
-        font-weight: bold;
       }
     }
   }

--- a/themes/roomify/roomify_bootstrap_wide/assets/sass/regions/_sidebar-wrapper.scss
+++ b/themes/roomify/roomify_bootstrap_wide/assets/sass/regions/_sidebar-wrapper.scss
@@ -1,7 +1,6 @@
-
 body {
   padding-right: 0;
-  @include transition(70ms all linear);
+  @include transition(60ms all linear);
   #sidebar-wrapper {
     z-index: 1000;
     position: fixed;
@@ -12,13 +11,15 @@ body {
     overflow-y: auto;
     background: #000;
     overflow-x: hidden;
-    @include transition(70ms all linear);
-    @include transition(2ms width linear);
+    @include transition(60ms all linear);
     .close-sidebar {
       border-bottom: 0;
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px;
+      &:after {
+        display: none;
+      }
     }
     #close-sidebar-icon {
       background: url('../images/close.png') center center no-repeat;
@@ -45,11 +46,24 @@ body {
     .panel-pane {
       display: inline-block;
       width: 100%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
+      margin-bottom: 10px;
       padding-bottom: 30px;
+      min-width: 320px;
+      &:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px;
+      }
       &:last-child {
-        border-bottom: none;
+        &:after {
+          display: none;
+        }
       }
       .pane-title {
         border-bottom: 0;
@@ -57,12 +71,12 @@ body {
         width: 100%;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
         font-size: 22px;
-        text-align: center;
       }
     }
     .pane-roomify-sidebar-user-menu {
+
       .pane-title {
         margin-bottom: 5px;
         font-size: 22px;
@@ -184,7 +198,7 @@ body {
         display: none;
       }
       .glyphicon {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -228,14 +242,15 @@ body {
         font-weight: 400;
         border-bottom: 0;
         font-size: 22px;
-        text-align: center;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
+          top: 2px;
+          right: 4px;
         }
         a {
           color: white;
@@ -292,12 +307,13 @@ body {
         color: white;
         font-weight: 400;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
@@ -343,12 +359,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
         color: white;
-        text-align: center;
       }
       .view-my-stays {
         .views-row {
@@ -384,8 +400,6 @@ body {
       }
     }
   }
-
-
   &.toggled {
     padding-right: 350px;
     margin-left: -350px;
@@ -408,6 +422,11 @@ body {
       margin-left: -300px;
       #sidebar-wrapper {
         width: 300px;
+      }
+      .sidebar-nav {
+        .panel-pane {
+          min-width: 280px;
+        }
       }
     }
   }
@@ -436,6 +455,6 @@ body.toggled {
     background: rgba(0, 0, 0, 0.35);
     height: 100%;
     cursor: pointer;
-    @include transition(80ms padding linear);
+    @include transition(60ms all linear);
   }
 }

--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -6,7 +6,7 @@
 html, body, div, span, applet, object, iframe,
 h1, h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .field-name-field-area-title-description,
 .page-taxonomy-area .field-name-field-area-title-blog-posts,
-.page-taxonomy-area .field-name-field-title-featured-properties, h3, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
+.page-taxonomy-area .field-name-field-title-featured-properties, h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-name, .page-activities-search .view-display-id-panel_pane_3 .property-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_3 .property-row .views-field-name, .page-blog .panel_sl_right .panel-pane .pane-title, .node-type-blog .panel_sl_right .panel-pane .pane-title, .page-things-to-do .panel_sl_right .panel-pane .pane-title, .node-type-activity .panel_sl_right .panel-pane .pane-title, .page-taxonomy-area .field-name-field-area-description-subtitle,
 .page-taxonomy-area .field-name-field-area-description-blog-post,
@@ -315,6 +315,7 @@ th {
   .page-taxonomy-area .field-name-field-area-title-blog-posts,
   .page-taxonomy-area .field-name-field-title-featured-properties,
   h3,
+  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message,
   .page-listing .pane-roomify-property-name,
   .page-checkout-review .checkout_review .pane-title td,
   .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
@@ -337,6 +338,7 @@ th {
   .page-taxonomy-area .field-name-field-area-title-blog-posts,
   .page-taxonomy-area .field-name-field-title-featured-properties,
   h3,
+  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message,
   .page-listing .pane-roomify-property-name,
   .page-checkout-review .checkout_review .pane-title td,
   .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
@@ -357,17 +359,8 @@ th {
   .navbar {
     display: none; }
 
-  .btn > .caret, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue > .caret, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back > .caret,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel > .caret, .page-blog .pager-load-more a > .caret,
-  .page-blog .roomify-add-button > .caret, .page-taxonomy-area .field-name-field-field-link-to-area-blog a > .caret, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button > .caret,
-  .dropup > .btn > .caret,
-  .page-checkout fieldset.panel-default.checkout-buttons .dropup > .checkout-continue > .caret,
-  .page-checkout fieldset.panel-default.checkout-buttons .dropup > .checkout-back > .caret,
-  .page-checkout fieldset.panel-default.checkout-buttons .dropup > .checkout-cancel > .caret,
-  .page-blog .pager-load-more .dropup > a > .caret,
-  .page-blog .dropup > .roomify-add-button > .caret,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .dropup > a > .caret,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .dropup > button > .caret {
+  .btn > .caret,
+  .dropup > .btn > .caret {
     border-top-color: #000 !important; }
 
   .label {
@@ -386,8 +379,7 @@ th {
   font-family: 'Glyphicons Halflings';
   src: url("../fonts/bootstrap/glyphicons-halflings-regular.eot");
   src: url("../fonts/bootstrap/glyphicons-halflings-regular.eot?#iefix") format("embedded-opentype"), url("../fonts/bootstrap/glyphicons-halflings-regular.woff2") format("woff2"), url("../fonts/bootstrap/glyphicons-halflings-regular.woff") format("woff"), url("../fonts/bootstrap/glyphicons-halflings-regular.ttf") format("truetype"), url("../fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular") format("svg"); }
-.glyphicon, .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-.page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before {
+.glyphicon {
   position: relative;
   top: 1px;
   display: inline-block;
@@ -1284,13 +1276,13 @@ hr {
 
 h1, h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .field-name-field-area-title-description,
 .page-taxonomy-area .field-name-field-area-title-blog-posts,
-.page-taxonomy-area .field-name-field-title-featured-properties, h3, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
+.page-taxonomy-area .field-name-field-title-featured-properties, h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-name, .page-activities-search .view-display-id-panel_pane_3 .property-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_3 .property-row .views-field-name, .page-blog .panel_sl_right .panel-pane .pane-title, .node-type-blog .panel_sl_right .panel-pane .pane-title, .page-things-to-do .panel_sl_right .panel-pane .pane-title, .node-type-activity .panel_sl_right .panel-pane .pane-title, .page-taxonomy-area .field-name-field-area-description-subtitle,
 .page-taxonomy-area .field-name-field-area-description-blog-post,
 .page-taxonomy-area .field-name-field-desc-featured-properities, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title, .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title, h4, .pane-property-location .panel-content-right .pane-title,
 .pane-property-location .panel-content-left .pane-title, .page-listing .pane-roomify-property-field-sp-short-description, .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .views-field-name, h5, h6,
-.h1, .h2, .h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message, .h4, .h5, .h6 {
+.h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: inherit;
   font-weight: 400;
   line-height: 1.1;
@@ -1303,12 +1295,13 @@ h1, h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .
   .page-taxonomy-area .pane-term-name .pane-content .small,
   .page-taxonomy-area .field-name-field-area-title-description .small,
   .page-taxonomy-area .field-name-field-area-title-blog-posts .small,
-  .page-taxonomy-area .field-name-field-title-featured-properties .small, h3 small, .page-listing .pane-roomify-property-name small, .page-checkout-review .checkout_review .pane-title td small, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name small,
+  .page-taxonomy-area .field-name-field-title-featured-properties .small, h3 small, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message small, .page-listing .pane-roomify-property-name small, .page-checkout-review .checkout_review .pane-title td small, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name small,
   .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-name small, .page-activities-search .view-display-id-panel_pane_3 .property-row .views-field-name small,
   .page-availability-search .view-display-id-panel_pane_3 .property-row .views-field-name small, .page-blog .panel_sl_right .panel-pane .pane-title small, .node-type-blog .panel_sl_right .panel-pane .pane-title small, .page-things-to-do .panel_sl_right .panel-pane .pane-title small, .node-type-activity .panel_sl_right .panel-pane .pane-title small, .page-taxonomy-area .field-name-field-area-description-subtitle small,
   .page-taxonomy-area .field-name-field-area-description-blog-post small,
   .page-taxonomy-area .field-name-field-desc-featured-properities small, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title small, .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title small,
   h3 .small,
+  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message .small,
   .page-listing .pane-roomify-property-name .small,
   .page-checkout-review .checkout_review .pane-title td .small,
   .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name .small,
@@ -1334,9 +1327,8 @@ h1, h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .
   h6 .small,
   .h1 small,
   .h1 .small, .h2 small,
-  .h2 .small, .h3 small, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message small,
-  .h3 .small,
-  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message .small, .h4 small,
+  .h2 .small, .h3 small,
+  .h3 .small, .h4 small,
   .h4 .small, .h5 small,
   .h5 .small, .h6 small,
   .h6 .small {
@@ -1351,6 +1343,7 @@ h2,
 .page-taxonomy-area .field-name-field-area-title-blog-posts,
 .page-taxonomy-area .field-name-field-title-featured-properties, .h2,
 h3,
+body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message,
 .page-listing .pane-roomify-property-name,
 .page-checkout-review .checkout_review .pane-title td,
 .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
@@ -1365,7 +1358,7 @@ h3,
 .page-taxonomy-area .field-name-field-area-description-blog-post,
 .page-taxonomy-area .field-name-field-desc-featured-properities,
 .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title,
-.page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title, .h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message {
+.page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title, .h3 {
   margin-top: 21px;
   margin-bottom: 10.5px; }
   h1 small,
@@ -1383,6 +1376,7 @@ h3,
   .page-taxonomy-area .field-name-field-title-featured-properties .small, .h2 small,
   .h2 .small,
   h3 small,
+  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message small,
   .page-listing .pane-roomify-property-name small,
   .page-checkout-review .checkout_review .pane-title td small,
   .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name small,
@@ -1399,6 +1393,7 @@ h3,
   .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title small,
   .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title small,
   h3 .small,
+  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message .small,
   .page-listing .pane-roomify-property-name .small,
   .page-checkout-review .checkout_review .pane-title td .small,
   .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name .small,
@@ -1413,9 +1408,8 @@ h3,
   .page-taxonomy-area .field-name-field-area-description-blog-post .small,
   .page-taxonomy-area .field-name-field-desc-featured-properities .small,
   .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title .small,
-  .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .small, .h3 small, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message small,
-  .h3 .small,
-  body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message .small {
+  .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .small, .h3 small,
+  .h3 .small {
     font-size: 65%; }
 
 h4, .pane-property-location .panel-content-right .pane-title,
@@ -1448,11 +1442,11 @@ h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .fiel
 .page-taxonomy-area .field-name-field-title-featured-properties, .h2 {
   font-size: 32px; }
 
-h3, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
+h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-name, .page-activities-search .view-display-id-panel_pane_3 .property-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_3 .property-row .views-field-name, .page-blog .panel_sl_right .panel-pane .pane-title, .node-type-blog .panel_sl_right .panel-pane .pane-title, .page-things-to-do .panel_sl_right .panel-pane .pane-title, .node-type-activity .panel_sl_right .panel-pane .pane-title, .page-taxonomy-area .field-name-field-area-description-subtitle,
 .page-taxonomy-area .field-name-field-area-description-blog-post,
-.page-taxonomy-area .field-name-field-desc-featured-properities, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title, .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title, .h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message {
+.page-taxonomy-area .field-name-field-desc-featured-properities, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title, .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title, .h3 {
   font-size: 25px; }
 
 h4, .pane-property-location .panel-content-right .pane-title,
@@ -1751,31 +1745,24 @@ pre {
   max-height: 340px;
   overflow-y: scroll; }
 
-.container, .messages-container, .page-taxonomy-area .panel_sl_content, body.page-single-property-listing .panel-content-wrapper,
-body.page-single-property-listing .panel-content-bottom {
+.container {
   margin-right: auto;
   margin-left: auto;
   padding-left: 15px;
   padding-right: 15px; }
-  .container:before, .messages-container:before, .page-taxonomy-area .panel_sl_content:before, body.page-single-property-listing .panel-content-wrapper:before,
-  body.page-single-property-listing .panel-content-bottom:before, .container:after, .messages-container:after, .page-taxonomy-area .panel_sl_content:after, body.page-single-property-listing .panel-content-wrapper:after,
-  body.page-single-property-listing .panel-content-bottom:after {
+  .container:before, .container:after {
     content: " ";
     display: table; }
-  .container:after, .messages-container:after, .page-taxonomy-area .panel_sl_content:after, body.page-single-property-listing .panel-content-wrapper:after,
-  body.page-single-property-listing .panel-content-bottom:after {
+  .container:after {
     clear: both; }
   @media (min-width: 768px) {
-    .container, .messages-container, .page-taxonomy-area .panel_sl_content, body.page-single-property-listing .panel-content-wrapper,
-    body.page-single-property-listing .panel-content-bottom {
+    .container {
       width: 750px; } }
   @media (min-width: 992px) {
-    .container, .messages-container, .page-taxonomy-area .panel_sl_content, body.page-single-property-listing .panel-content-wrapper,
-    body.page-single-property-listing .panel-content-bottom {
+    .container {
       width: 970px; } }
   @media (min-width: 1200px) {
-    .container, .messages-container, .page-taxonomy-area .panel_sl_content, body.page-single-property-listing .panel-content-wrapper,
-    body.page-single-property-listing .panel-content-bottom {
+    .container {
       width: 1170px; } }
 
 .container-fluid {
@@ -2738,72 +2725,40 @@ input[type="search"] {
     line-height: 39px; }
   input[type="date"].input-sm, .input-group-sm > input[type="date"].form-control,
   .input-group-sm > input[type="date"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="date"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="date"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="date"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="date"].checkout-cancel,
-  .page-blog .input-group-sm > .input-group-btn > input[type="date"].roomify-add-button, .input-group-sm input[type="date"],
+  .input-group-sm > .input-group-btn > input[type="date"].btn, .input-group-sm input[type="date"],
   input[type="time"].input-sm,
   .input-group-sm > input[type="time"].form-control,
   .input-group-sm > input[type="time"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="time"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="time"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="time"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="time"].checkout-cancel,
-  .page-blog .input-group-sm > .input-group-btn > input[type="time"].roomify-add-button, .input-group-sm
+  .input-group-sm > .input-group-btn > input[type="time"].btn, .input-group-sm
   input[type="time"],
   input[type="datetime-local"].input-sm,
   .input-group-sm > input[type="datetime-local"].form-control,
   .input-group-sm > input[type="datetime-local"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="datetime-local"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="datetime-local"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="datetime-local"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="datetime-local"].checkout-cancel,
-  .page-blog .input-group-sm > .input-group-btn > input[type="datetime-local"].roomify-add-button, .input-group-sm
+  .input-group-sm > .input-group-btn > input[type="datetime-local"].btn, .input-group-sm
   input[type="datetime-local"],
   input[type="month"].input-sm,
   .input-group-sm > input[type="month"].form-control,
   .input-group-sm > input[type="month"].input-group-addon,
-  .input-group-sm > .input-group-btn > input[type="month"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="month"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="month"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > input[type="month"].checkout-cancel,
-  .page-blog .input-group-sm > .input-group-btn > input[type="month"].roomify-add-button, .input-group-sm
+  .input-group-sm > .input-group-btn > input[type="month"].btn, .input-group-sm
   input[type="month"] {
     line-height: 29px; }
   input[type="date"].input-lg, .input-group-lg > input[type="date"].form-control,
   .input-group-lg > input[type="date"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="date"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="date"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="date"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="date"].checkout-cancel,
-  .page-blog .input-group-lg > .input-group-btn > input[type="date"].roomify-add-button, .input-group-lg input[type="date"],
+  .input-group-lg > .input-group-btn > input[type="date"].btn, .input-group-lg input[type="date"],
   input[type="time"].input-lg,
   .input-group-lg > input[type="time"].form-control,
   .input-group-lg > input[type="time"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="time"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="time"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="time"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="time"].checkout-cancel,
-  .page-blog .input-group-lg > .input-group-btn > input[type="time"].roomify-add-button, .input-group-lg
+  .input-group-lg > .input-group-btn > input[type="time"].btn, .input-group-lg
   input[type="time"],
   input[type="datetime-local"].input-lg,
   .input-group-lg > input[type="datetime-local"].form-control,
   .input-group-lg > input[type="datetime-local"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="datetime-local"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="datetime-local"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="datetime-local"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="datetime-local"].checkout-cancel,
-  .page-blog .input-group-lg > .input-group-btn > input[type="datetime-local"].roomify-add-button, .input-group-lg
+  .input-group-lg > .input-group-btn > input[type="datetime-local"].btn, .input-group-lg
   input[type="datetime-local"],
   input[type="month"].input-lg,
   .input-group-lg > input[type="month"].form-control,
   .input-group-lg > input[type="month"].input-group-addon,
-  .input-group-lg > .input-group-btn > input[type="month"].btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="month"].checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="month"].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > input[type="month"].checkout-cancel,
-  .page-blog .input-group-lg > .input-group-btn > input[type="month"].roomify-add-button, .input-group-lg
+  .input-group-lg > .input-group-btn > input[type="month"].btn, .input-group-lg
   input[type="month"] {
     line-height: 54px; } }
 .form-group {
@@ -2873,36 +2828,15 @@ input[type="checkbox"] {
   min-height: 36px; }
   .form-control-static.input-lg, .input-group-lg > .form-control-static.form-control,
   .input-group-lg > .form-control-static.input-group-addon,
-  .input-group-lg > .input-group-btn > .form-control-static.btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .form-control-static.checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .form-control-static.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .form-control-static.checkout-cancel,
-  .page-blog .pager-load-more .input-group-lg > .input-group-btn > a.form-control-static,
-  .page-blog .input-group-lg > .input-group-btn > .form-control-static.roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-lg > .input-group-btn > a.form-control-static,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-lg > .input-group-btn > button.form-control-static, .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control,
+  .input-group-lg > .input-group-btn > .form-control-static.btn, .form-control-static.input-sm, .input-group-sm > .form-control-static.form-control,
   .input-group-sm > .form-control-static.input-group-addon,
-  .input-group-sm > .input-group-btn > .form-control-static.btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .form-control-static.checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .form-control-static.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .form-control-static.checkout-cancel,
-  .page-blog .pager-load-more .input-group-sm > .input-group-btn > a.form-control-static,
-  .page-blog .input-group-sm > .input-group-btn > .form-control-static.roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-sm > .input-group-btn > a.form-control-static,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-sm > .input-group-btn > button.form-control-static {
+  .input-group-sm > .input-group-btn > .form-control-static.btn {
     padding-left: 0;
     padding-right: 0; }
 
 .input-sm, .input-group-sm > .form-control,
 .input-group-sm > .input-group-addon,
-.input-group-sm > .input-group-btn > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .checkout-cancel,
-.page-blog .pager-load-more .input-group-sm > .input-group-btn > a,
-.page-blog .input-group-sm > .input-group-btn > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-sm > .input-group-btn > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-sm > .input-group-btn > button {
+.input-group-sm > .input-group-btn > .btn {
   height: 29px;
   padding: 4px 10px;
   font-size: 13px;
@@ -2911,29 +2845,17 @@ input[type="checkbox"] {
 
 select.input-sm, .input-group-sm > select.form-control,
 .input-group-sm > select.input-group-addon,
-.input-group-sm > .input-group-btn > select.btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > select.checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > select.checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > select.checkout-cancel,
-.page-blog .input-group-sm > .input-group-btn > select.roomify-add-button {
+.input-group-sm > .input-group-btn > select.btn {
   height: 29px;
   line-height: 29px; }
 
 textarea.input-sm, .input-group-sm > textarea.form-control,
 .input-group-sm > textarea.input-group-addon,
 .input-group-sm > .input-group-btn > textarea.btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > textarea.checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > textarea.checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > textarea.checkout-cancel,
-.page-blog .input-group-sm > .input-group-btn > textarea.roomify-add-button,
 select[multiple].input-sm,
 .input-group-sm > select[multiple].form-control,
 .input-group-sm > select[multiple].input-group-addon,
-.input-group-sm > .input-group-btn > select[multiple].btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > select[multiple].checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > select[multiple].checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > select[multiple].checkout-cancel,
-.page-blog .input-group-sm > .input-group-btn > select[multiple].roomify-add-button {
+.input-group-sm > .input-group-btn > select[multiple].btn {
   height: auto; }
 
 .form-group-sm .form-control {
@@ -2957,14 +2879,7 @@ select[multiple].input-sm,
 
 .input-lg, .input-group-lg > .form-control,
 .input-group-lg > .input-group-addon,
-.input-group-lg > .input-group-btn > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .checkout-cancel,
-.page-blog .pager-load-more .input-group-lg > .input-group-btn > a,
-.page-blog .input-group-lg > .input-group-btn > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-lg > .input-group-btn > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-lg > .input-group-btn > button {
+.input-group-lg > .input-group-btn > .btn {
   height: 54px;
   padding: 13px 16px;
   font-size: 19px;
@@ -2973,29 +2888,17 @@ select[multiple].input-sm,
 
 select.input-lg, .input-group-lg > select.form-control,
 .input-group-lg > select.input-group-addon,
-.input-group-lg > .input-group-btn > select.btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > select.checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > select.checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > select.checkout-cancel,
-.page-blog .input-group-lg > .input-group-btn > select.roomify-add-button {
+.input-group-lg > .input-group-btn > select.btn {
   height: 54px;
   line-height: 54px; }
 
 textarea.input-lg, .input-group-lg > textarea.form-control,
 .input-group-lg > textarea.input-group-addon,
 .input-group-lg > .input-group-btn > textarea.btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > textarea.checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > textarea.checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > textarea.checkout-cancel,
-.page-blog .input-group-lg > .input-group-btn > textarea.roomify-add-button,
 select[multiple].input-lg,
 .input-group-lg > select[multiple].form-control,
 .input-group-lg > select[multiple].input-group-addon,
-.input-group-lg > .input-group-btn > select[multiple].btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > select[multiple].checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > select[multiple].checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > select[multiple].checkout-cancel,
-.page-blog .input-group-lg > .input-group-btn > select[multiple].roomify-add-button {
+.input-group-lg > .input-group-btn > select[multiple].btn {
   height: auto; }
 
 .form-group-lg .form-control {
@@ -3037,13 +2940,6 @@ select[multiple].input-lg,
 .input-lg + .form-control-feedback, .input-group-lg > .form-control + .form-control-feedback,
 .input-group-lg > .input-group-addon + .form-control-feedback,
 .input-group-lg > .input-group-btn > .btn + .form-control-feedback,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .checkout-continue + .form-control-feedback,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .checkout-back + .form-control-feedback,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .checkout-cancel + .form-control-feedback,
-.page-blog .pager-load-more .input-group-lg > .input-group-btn > a + .form-control-feedback,
-.page-blog .input-group-lg > .input-group-btn > .roomify-add-button + .form-control-feedback,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-lg > .input-group-btn > a + .form-control-feedback,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-lg > .input-group-btn > button + .form-control-feedback,
 .input-group-lg + .form-control-feedback,
 .form-group-lg .form-control + .form-control-feedback {
   width: 54px;
@@ -3053,13 +2949,6 @@ select[multiple].input-lg,
 .input-sm + .form-control-feedback, .input-group-sm > .form-control + .form-control-feedback,
 .input-group-sm > .input-group-addon + .form-control-feedback,
 .input-group-sm > .input-group-btn > .btn + .form-control-feedback,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .checkout-continue + .form-control-feedback,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .checkout-back + .form-control-feedback,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .checkout-cancel + .form-control-feedback,
-.page-blog .pager-load-more .input-group-sm > .input-group-btn > a + .form-control-feedback,
-.page-blog .input-group-sm > .input-group-btn > .roomify-add-button + .form-control-feedback,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-sm > .input-group-btn > a + .form-control-feedback,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-sm > .input-group-btn > button + .form-control-feedback,
 .input-group-sm + .form-control-feedback,
 .form-group-sm .form-control + .form-control-feedback {
   width: 29px;
@@ -3216,9 +3105,7 @@ select[multiple].input-lg,
     padding-top: 5px;
     font-size: 13px; } }
 
-.btn, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel, .page-blog .pager-load-more a,
-.page-blog .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button {
+.btn {
   display: inline-block;
   margin-bottom: 0;
   font-weight: 300;
@@ -3237,153 +3124,53 @@ select[multiple].input-lg,
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none; }
-  .btn:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus, .page-blog .pager-load-more a:focus,
-  .page-blog .roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, .btn.focus, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-cancel, .page-blog .pager-load-more a.focus,
-  .page-blog .focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.focus, .btn:active:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active:focus, .page-blog .pager-load-more a:active:focus,
-  .page-blog .roomify-add-button:active:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active:focus, .btn:active.focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active.focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active.focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active.focus, .page-blog .pager-load-more a:active.focus,
-  .page-blog .roomify-add-button:active.focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active.focus, .btn.active:focus, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel:focus, .page-blog .pager-load-more a.active:focus,
-  .page-blog .active.roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active:focus, .btn.active.focus, .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-cancel, .page-blog .pager-load-more a.active.focus,
-  .page-blog .active.focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active.focus {
+  .btn:focus, .btn.focus, .btn:active:focus, .btn:active.focus, .btn.active:focus, .btn.active.focus {
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px; }
-  .btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover, .page-blog .pager-load-more a:hover,
-  .page-blog .roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover, .btn:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus, .page-blog .pager-load-more a:focus,
-  .page-blog .roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, .btn.focus, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-cancel, .page-blog .pager-load-more a.focus,
-  .page-blog .focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.focus {
+  .btn:hover, .btn:focus, .btn.focus {
     color: #555555;
     text-decoration: none; }
-  .btn:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active, .page-blog .pager-load-more a:active,
-  .page-blog .roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active, .btn.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel, .page-blog .pager-load-more a.active,
-  .page-blog .active.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active {
+  .btn:active, .btn.active {
     outline: 0;
     background-image: none;
     -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
     box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
-  .btn.disabled, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-cancel, .page-blog .pager-load-more a.disabled,
-  .page-blog .disabled.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.disabled, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled, .btn[disabled], .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-cancel, .page-blog .pager-load-more a[disabled],
-  .page-blog [disabled].roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a[disabled], .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled], fieldset[disabled] .btn, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-continue, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-back,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-cancel, fieldset[disabled] .page-blog .pager-load-more a, .page-blog .pager-load-more fieldset[disabled] a,
-  fieldset[disabled] .page-blog .roomify-add-button,
-  .page-blog fieldset[disabled] .roomify-add-button, fieldset[disabled] .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog fieldset[disabled] a, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button {
+  .btn.disabled, .btn[disabled], fieldset[disabled] .btn {
     cursor: not-allowed;
     opacity: 0.65;
     filter: alpha(opacity=65);
     -webkit-box-shadow: none;
     box-shadow: none; }
 
-a.btn.disabled, .page-checkout fieldset.panel-default.checkout-buttons a.disabled.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons a.disabled.checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons a.disabled.checkout-cancel, .page-blog .pager-load-more a.disabled,
-.page-blog a.disabled.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.disabled, fieldset[disabled] a.btn, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons a.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] a.checkout-continue, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons a.checkout-back, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] a.checkout-back,
-fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons a.checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] a.checkout-cancel, fieldset[disabled] .page-blog .pager-load-more a, .page-blog .pager-load-more fieldset[disabled] a,
-fieldset[disabled] .page-blog a.roomify-add-button,
-.page-blog fieldset[disabled] a.roomify-add-button, fieldset[disabled] .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog fieldset[disabled] a {
+a.btn.disabled, fieldset[disabled] a.btn {
   pointer-events: none; }
 
-.btn-default, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel, .page-blog .pager-load-more a,
-.page-blog .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button {
+.btn-default {
   color: #555555;
   background-color: #eeeeee;
   border-color: #e2e2e2; }
-  .btn-default:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus, .page-blog .pager-load-more a:focus,
-  .page-blog .roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, .btn-default.focus, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-cancel, .page-blog .pager-load-more a.focus,
-  .page-blog .focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.focus {
+  .btn-default:focus, .btn-default.focus {
     color: #555555;
     background-color: #d5d5d5;
     border-color: #a2a2a2; }
-  .btn-default:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover, .page-blog .pager-load-more a:hover,
-  .page-blog .roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover {
+  .btn-default:hover {
     color: #555555;
     background-color: #d5d5d5;
     border-color: #c3c3c3; }
-  .btn-default:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active, .page-blog .pager-load-more a:active,
-  .page-blog .roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active, .btn-default.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel, .page-blog .pager-load-more a.active,
-  .page-blog .active.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active, .open > .btn-default.dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel, .page-blog .pager-load-more .open > a.dropdown-toggle,
-  .page-blog .open > .dropdown-toggle.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .open > a.dropdown-toggle, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle {
+  .btn-default:active, .btn-default.active, .open > .btn-default.dropdown-toggle {
     color: #555555;
     background-color: #d5d5d5;
     border-color: #c3c3c3; }
-    .btn-default:active:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active:hover, .page-blog .pager-load-more a:active:hover,
-    .page-blog .roomify-add-button:active:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active:hover, .btn-default:active:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active:focus, .page-blog .pager-load-more a:active:focus,
-    .page-blog .roomify-add-button:active:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active:focus, .btn-default:active.focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active.focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active.focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active.focus, .page-blog .pager-load-more a:active.focus,
-    .page-blog .roomify-add-button:active.focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active.focus, .btn-default.active:hover, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel:hover, .page-blog .pager-load-more a.active:hover,
-    .page-blog .active.roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active:hover, .btn-default.active:focus, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel:focus, .page-blog .pager-load-more a.active:focus,
-    .page-blog .active.roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active:focus, .btn-default.active.focus, .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-cancel, .page-blog .pager-load-more a.active.focus,
-    .page-blog .active.focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active.focus, .open > .btn-default.dropdown-toggle:hover, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel:hover, .page-blog .pager-load-more .open > a.dropdown-toggle:hover,
-    .page-blog .open > .dropdown-toggle.roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .open > a.dropdown-toggle:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle:hover, .open > .btn-default.dropdown-toggle:focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel:focus, .page-blog .pager-load-more .open > a.dropdown-toggle:focus,
-    .page-blog .open > .dropdown-toggle.roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog .open > a.dropdown-toggle:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle:focus, .open > .btn-default.dropdown-toggle.focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.focus.checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.focus.checkout-cancel, .page-blog .pager-load-more .open > a.dropdown-toggle.focus,
-    .page-blog .open > .dropdown-toggle.focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .open > a.dropdown-toggle.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle.focus {
+    .btn-default:active:hover, .btn-default:active:focus, .btn-default:active.focus, .btn-default.active:hover, .btn-default.active:focus, .btn-default.active.focus, .open > .btn-default.dropdown-toggle:hover, .open > .btn-default.dropdown-toggle:focus, .open > .btn-default.dropdown-toggle.focus {
       color: #555555;
       background-color: #c3c3c3;
       border-color: #a2a2a2; }
-  .btn-default:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active, .page-blog .pager-load-more a:active,
-  .page-blog .roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active, .btn-default.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel, .page-blog .pager-load-more a.active,
-  .page-blog .active.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active, .open > .btn-default.dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel, .page-blog .pager-load-more .open > a.dropdown-toggle,
-  .page-blog .open > .dropdown-toggle.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .open > a.dropdown-toggle, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle {
+  .btn-default:active, .btn-default.active, .open > .btn-default.dropdown-toggle {
     background-image: none; }
-  .btn-default.disabled:hover, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-cancel:hover, .page-blog .pager-load-more a.disabled:hover,
-  .page-blog .disabled.roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.disabled:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled:hover, .btn-default.disabled:focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-cancel:focus, .page-blog .pager-load-more a.disabled:focus,
-  .page-blog .disabled.roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.disabled:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled:focus, .btn-default.disabled.focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .disabled.focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.focus.checkout-cancel, .page-blog .pager-load-more a.disabled.focus,
-  .page-blog .disabled.focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a.disabled.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled.focus, .btn-default[disabled]:hover, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-cancel:hover, .page-blog .pager-load-more a[disabled]:hover,
-  .page-blog [disabled].roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a[disabled]:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled]:hover, .btn-default[disabled]:focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-cancel:focus, .page-blog .pager-load-more a[disabled]:focus,
-  .page-blog [disabled].roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a[disabled]:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled]:focus, .btn-default[disabled].focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons [disabled].focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].focus.checkout-cancel, .page-blog .pager-load-more a[disabled].focus,
-  .page-blog [disabled].focus.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a[disabled].focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled].focus, fieldset[disabled] .btn-default:hover, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-continue:hover, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-back:hover,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-cancel:hover, fieldset[disabled] .page-blog .pager-load-more a:hover, .page-blog .pager-load-more fieldset[disabled] a:hover,
-  fieldset[disabled] .page-blog .roomify-add-button:hover,
-  .page-blog fieldset[disabled] .roomify-add-button:hover, fieldset[disabled] .page-taxonomy-area .field-name-field-field-link-to-area-blog a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog fieldset[disabled] a:hover, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button:hover, fieldset[disabled] .btn-default:focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-continue:focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-back:focus,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-cancel:focus, fieldset[disabled] .page-blog .pager-load-more a:focus, .page-blog .pager-load-more fieldset[disabled] a:focus,
-  fieldset[disabled] .page-blog .roomify-add-button:focus,
-  .page-blog fieldset[disabled] .roomify-add-button:focus, fieldset[disabled] .page-taxonomy-area .field-name-field-field-link-to-area-blog a:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog fieldset[disabled] a:focus, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button:focus, fieldset[disabled] .btn-default.focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .focus.checkout-continue, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-back, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .focus.checkout-back,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .focus.checkout-cancel, fieldset[disabled] .page-blog .pager-load-more a.focus, .page-blog .pager-load-more fieldset[disabled] a.focus,
-  fieldset[disabled] .page-blog .focus.roomify-add-button,
-  .page-blog fieldset[disabled] .focus.roomify-add-button, fieldset[disabled] .page-taxonomy-area .field-name-field-field-link-to-area-blog a.focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog fieldset[disabled] a.focus, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button.focus {
+  .btn-default.disabled:hover, .btn-default.disabled:focus, .btn-default.disabled.focus, .btn-default[disabled]:hover, .btn-default[disabled]:focus, .btn-default[disabled].focus, fieldset[disabled] .btn-default:hover, fieldset[disabled] .btn-default:focus, fieldset[disabled] .btn-default.focus {
     background-color: #eeeeee;
     border-color: #e2e2e2; }
-  .btn-default .badge, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue .badge, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back .badge,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel .badge, .page-blog .pager-load-more a .badge,
-  .page-blog .roomify-add-button .badge, .page-taxonomy-area .field-name-field-field-link-to-area-blog a .badge, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button .badge {
+  .btn-default .badge {
     color: #eeeeee;
     background-color: #555555; }
 
@@ -3416,32 +3203,32 @@ fieldset[disabled] .page-blog a.roomify-add-button,
     color: #158CBA;
     background-color: #fff; }
 
-.btn-success, body .sidebar-nav .pane-user-login .form-actions button, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue {
+.btn-success {
   color: #fff;
   background-color: #28B62C;
   border-color: #23a127; }
-  .btn-success:focus, body .sidebar-nav .pane-user-login .form-actions button:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .btn-success.focus, body .sidebar-nav .pane-user-login .form-actions button.focus, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-continue {
+  .btn-success:focus, .btn-success.focus {
     color: #fff;
     background-color: #1f8c22;
     border-color: #0c390e; }
-  .btn-success:hover, body .sidebar-nav .pane-user-login .form-actions button:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover {
+  .btn-success:hover {
     color: #fff;
     background-color: #1f8c22;
     border-color: #186f1b; }
-  .btn-success:active, body .sidebar-nav .pane-user-login .form-actions button:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active, .btn-success.active, body .sidebar-nav .pane-user-login .form-actions button.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue, .open > .btn-success.dropdown-toggle, body .sidebar-nav .pane-user-login .form-actions .open > button.dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue {
+  .btn-success:active, .btn-success.active, .open > .btn-success.dropdown-toggle {
     color: #fff;
     background-color: #1f8c22;
     border-color: #186f1b; }
-    .btn-success:active:hover, body .sidebar-nav .pane-user-login .form-actions button:active:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active:hover, .btn-success:active:focus, body .sidebar-nav .pane-user-login .form-actions button:active:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active:focus, .btn-success:active.focus, body .sidebar-nav .pane-user-login .form-actions button:active.focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active.focus, .btn-success.active:hover, body .sidebar-nav .pane-user-login .form-actions button.active:hover, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue:hover, .btn-success.active:focus, body .sidebar-nav .pane-user-login .form-actions button.active:focus, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue:focus, .btn-success.active.focus, body .sidebar-nav .pane-user-login .form-actions button.active.focus, .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-continue, .open > .btn-success.dropdown-toggle:hover, body .sidebar-nav .pane-user-login .form-actions .open > button.dropdown-toggle:hover, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue:hover, .open > .btn-success.dropdown-toggle:focus, body .sidebar-nav .pane-user-login .form-actions .open > button.dropdown-toggle:focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue:focus, .open > .btn-success.dropdown-toggle.focus, body .sidebar-nav .pane-user-login .form-actions .open > button.dropdown-toggle.focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.focus.checkout-continue {
+    .btn-success:active:hover, .btn-success:active:focus, .btn-success:active.focus, .btn-success.active:hover, .btn-success.active:focus, .btn-success.active.focus, .open > .btn-success.dropdown-toggle:hover, .open > .btn-success.dropdown-toggle:focus, .open > .btn-success.dropdown-toggle.focus {
       color: #fff;
       background-color: #186f1b;
       border-color: #0c390e; }
-  .btn-success:active, body .sidebar-nav .pane-user-login .form-actions button:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active, .btn-success.active, body .sidebar-nav .pane-user-login .form-actions button.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-continue, .open > .btn-success.dropdown-toggle, body .sidebar-nav .pane-user-login .form-actions .open > button.dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-continue {
+  .btn-success:active, .btn-success.active, .open > .btn-success.dropdown-toggle {
     background-image: none; }
-  .btn-success.disabled:hover, body .sidebar-nav .pane-user-login .form-actions button.disabled:hover, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-continue:hover, .btn-success.disabled:focus, body .sidebar-nav .pane-user-login .form-actions button.disabled:focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-continue:focus, .btn-success.disabled.focus, body .sidebar-nav .pane-user-login .form-actions button.disabled.focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.focus.checkout-continue, .btn-success[disabled]:hover, body .sidebar-nav .pane-user-login .form-actions button[disabled]:hover, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-continue:hover, .btn-success[disabled]:focus, body .sidebar-nav .pane-user-login .form-actions button[disabled]:focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-continue:focus, .btn-success[disabled].focus, body .sidebar-nav .pane-user-login .form-actions button[disabled].focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].focus.checkout-continue, fieldset[disabled] .btn-success:hover, fieldset[disabled] body .sidebar-nav .pane-user-login .form-actions button:hover, body .sidebar-nav .pane-user-login .form-actions fieldset[disabled] button:hover, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-continue:hover, fieldset[disabled] .btn-success:focus, fieldset[disabled] body .sidebar-nav .pane-user-login .form-actions button:focus, body .sidebar-nav .pane-user-login .form-actions fieldset[disabled] button:focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-continue:focus, fieldset[disabled] .btn-success.focus, fieldset[disabled] body .sidebar-nav .pane-user-login .form-actions button.focus, body .sidebar-nav .pane-user-login .form-actions fieldset[disabled] button.focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .focus.checkout-continue {
+  .btn-success.disabled:hover, .btn-success.disabled:focus, .btn-success.disabled.focus, .btn-success[disabled]:hover, .btn-success[disabled]:focus, .btn-success[disabled].focus, fieldset[disabled] .btn-success:hover, fieldset[disabled] .btn-success:focus, fieldset[disabled] .btn-success.focus {
     background-color: #28B62C;
     border-color: #23a127; }
-  .btn-success .badge, body .sidebar-nav .pane-user-login .form-actions button .badge, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue .badge {
+  .btn-success .badge {
     color: #28B62C;
     background-color: #fff; }
 
@@ -3474,477 +3261,61 @@ fieldset[disabled] .page-blog a.roomify-add-button,
     color: #75CAEB;
     background-color: #fff; }
 
-.btn-warning, .page-checkout #edit-customer-profile-billing-edit-button {
+.btn-warning {
   color: #fff;
   background-color: #FF851B;
   border-color: #ff7702; }
-  .btn-warning:focus, .page-checkout #edit-customer-profile-billing-edit-button:focus, .btn-warning.focus, .page-checkout .focus#edit-customer-profile-billing-edit-button {
+  .btn-warning:focus, .btn-warning.focus {
     color: #fff;
     background-color: #e76b00;
     border-color: #813c00; }
-  .btn-warning:hover, .page-checkout #edit-customer-profile-billing-edit-button:hover {
+  .btn-warning:hover {
     color: #fff;
     background-color: #e76b00;
     border-color: #c35b00; }
-  .btn-warning:active, .page-checkout #edit-customer-profile-billing-edit-button:active, .btn-warning.active, .page-checkout .active#edit-customer-profile-billing-edit-button, .open > .btn-warning.dropdown-toggle, .page-checkout .open > .dropdown-toggle#edit-customer-profile-billing-edit-button {
+  .btn-warning:active, .btn-warning.active, .open > .btn-warning.dropdown-toggle {
     color: #fff;
     background-color: #e76b00;
     border-color: #c35b00; }
-    .btn-warning:active:hover, .page-checkout #edit-customer-profile-billing-edit-button:active:hover, .btn-warning:active:focus, .page-checkout #edit-customer-profile-billing-edit-button:active:focus, .btn-warning:active.focus, .page-checkout #edit-customer-profile-billing-edit-button:active.focus, .btn-warning.active:hover, .page-checkout .active#edit-customer-profile-billing-edit-button:hover, .btn-warning.active:focus, .page-checkout .active#edit-customer-profile-billing-edit-button:focus, .btn-warning.active.focus, .page-checkout .active.focus#edit-customer-profile-billing-edit-button, .open > .btn-warning.dropdown-toggle:hover, .page-checkout .open > .dropdown-toggle#edit-customer-profile-billing-edit-button:hover, .open > .btn-warning.dropdown-toggle:focus, .page-checkout .open > .dropdown-toggle#edit-customer-profile-billing-edit-button:focus, .open > .btn-warning.dropdown-toggle.focus, .page-checkout .open > .dropdown-toggle.focus#edit-customer-profile-billing-edit-button {
+    .btn-warning:active:hover, .btn-warning:active:focus, .btn-warning:active.focus, .btn-warning.active:hover, .btn-warning.active:focus, .btn-warning.active.focus, .open > .btn-warning.dropdown-toggle:hover, .open > .btn-warning.dropdown-toggle:focus, .open > .btn-warning.dropdown-toggle.focus {
       color: #fff;
       background-color: #c35b00;
       border-color: #813c00; }
-  .btn-warning:active, .page-checkout #edit-customer-profile-billing-edit-button:active, .btn-warning.active, .page-checkout .active#edit-customer-profile-billing-edit-button, .open > .btn-warning.dropdown-toggle, .page-checkout .open > .dropdown-toggle#edit-customer-profile-billing-edit-button {
+  .btn-warning:active, .btn-warning.active, .open > .btn-warning.dropdown-toggle {
     background-image: none; }
-  .btn-warning.disabled:hover, .page-checkout .disabled#edit-customer-profile-billing-edit-button:hover, .btn-warning.disabled:focus, .page-checkout .disabled#edit-customer-profile-billing-edit-button:focus, .btn-warning.disabled.focus, .page-checkout .disabled.focus#edit-customer-profile-billing-edit-button, .btn-warning[disabled]:hover, .page-checkout [disabled]#edit-customer-profile-billing-edit-button:hover, .btn-warning[disabled]:focus, .page-checkout [disabled]#edit-customer-profile-billing-edit-button:focus, .btn-warning[disabled].focus, .page-checkout [disabled].focus#edit-customer-profile-billing-edit-button, fieldset[disabled] .btn-warning:hover, fieldset[disabled] .page-checkout #edit-customer-profile-billing-edit-button:hover, .page-checkout fieldset[disabled] #edit-customer-profile-billing-edit-button:hover, fieldset[disabled] .btn-warning:focus, fieldset[disabled] .page-checkout #edit-customer-profile-billing-edit-button:focus, .page-checkout fieldset[disabled] #edit-customer-profile-billing-edit-button:focus, fieldset[disabled] .btn-warning.focus, fieldset[disabled] .page-checkout .focus#edit-customer-profile-billing-edit-button, .page-checkout fieldset[disabled] .focus#edit-customer-profile-billing-edit-button {
+  .btn-warning.disabled:hover, .btn-warning.disabled:focus, .btn-warning.disabled.focus, .btn-warning[disabled]:hover, .btn-warning[disabled]:focus, .btn-warning[disabled].focus, fieldset[disabled] .btn-warning:hover, fieldset[disabled] .btn-warning:focus, fieldset[disabled] .btn-warning.focus {
     background-color: #FF851B;
     border-color: #ff7702; }
-  .btn-warning .badge, .page-checkout #edit-customer-profile-billing-edit-button .badge {
+  .btn-warning .badge {
     color: #FF851B;
     background-color: #fff; }
 
-.btn-danger, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit,
-#property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit,
-#roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit,
-#roomify-property-search-block-form .form-wrapper .search-submit .form-submit,
-#property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit,
-#property-bat-facets-availability .form-wrapper .search-submit .form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit,
-body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit,
-body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit,
-body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit,
-body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit,
-body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit,
-body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit,
-body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit {
+.btn-danger {
   color: #fff;
   background-color: #FF4136;
   border-color: #ff291d; }
-  .btn-danger:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:focus,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:focus, .btn-danger.focus, .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .focus.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .focus.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .focus.form-submit {
+  .btn-danger:focus, .btn-danger.focus {
     color: #fff;
     background-color: #ff1103;
     border-color: #9c0900; }
-  .btn-danger:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:hover {
+  .btn-danger:hover {
     color: #fff;
     background-color: #ff1103;
     border-color: #de0c00; }
-  .btn-danger:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active, .btn-danger.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .active.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .active.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .active.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .active.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .active.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .active.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .active.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .active.form-submit, .open > .btn-danger.dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .open > .dropdown-toggle.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .open > .dropdown-toggle.form-submit {
+  .btn-danger:active, .btn-danger.active, .open > .btn-danger.dropdown-toggle {
     color: #fff;
     background-color: #ff1103;
     border-color: #de0c00; }
-    .btn-danger:active:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active:hover,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active:hover,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active:hover,
-    #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active:hover,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active:hover,
-    #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active:hover, .btn-danger:active:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active:focus,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active:focus,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active:focus,
-    #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active:focus,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active:focus,
-    #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active:focus, .btn-danger:active.focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active.focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active.focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active.focus,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active.focus,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active.focus,
-    #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active.focus,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active.focus,
-    #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active.focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active.focus, .btn-danger.active:hover, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .active.form-submit:hover,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .active.form-submit:hover,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .active.form-submit:hover,
-    #roomify-property-search-block-form .form-wrapper .search-submit .active.form-submit:hover,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .active.form-submit:hover,
-    #property-bat-facets-availability .form-wrapper .search-submit .active.form-submit:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .active.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .active.form-submit:hover, .btn-danger.active:focus, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .active.form-submit:focus,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .active.form-submit:focus,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .active.form-submit:focus,
-    #roomify-property-search-block-form .form-wrapper .search-submit .active.form-submit:focus,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .active.form-submit:focus,
-    #property-bat-facets-availability .form-wrapper .search-submit .active.form-submit:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .active.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .active.form-submit:focus, .btn-danger.active.focus, .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .active.focus.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .active.focus.form-submit,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .active.focus.form-submit,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .active.focus.form-submit,
-    #roomify-property-search-block-form .form-wrapper .search-submit .active.focus.form-submit,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .active.focus.form-submit,
-    #property-bat-facets-availability .form-wrapper .search-submit .active.focus.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .active.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .active.focus.form-submit, .open > .btn-danger.dropdown-toggle:hover, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit:hover,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit:hover,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit:hover,
-    #roomify-property-search-block-form .form-wrapper .search-submit .open > .dropdown-toggle.form-submit:hover,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit:hover,
-    #property-bat-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .open > .dropdown-toggle.form-submit:hover,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .open > .dropdown-toggle.form-submit:hover, .open > .btn-danger.dropdown-toggle:focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit:focus,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit:focus,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit:focus,
-    #roomify-property-search-block-form .form-wrapper .search-submit .open > .dropdown-toggle.form-submit:focus,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit:focus,
-    #property-bat-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .open > .dropdown-toggle.form-submit:focus,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .open > .dropdown-toggle.form-submit:focus, .open > .btn-danger.dropdown-toggle.focus, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.focus.checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.focus.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.focus.form-submit,
-    #property-bat-activity-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.focus.form-submit,
-    #roomify-property-search-block-form .form-wrapper .search-availability-submit .open > .dropdown-toggle.focus.form-submit,
-    #roomify-property-search-block-form .form-wrapper .search-submit .open > .dropdown-toggle.focus.form-submit,
-    #property-bat-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.focus.form-submit,
-    #property-bat-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.focus.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .open > .dropdown-toggle.focus.form-submit,
-    body.page-single-property-listing .pane-locanda-availability-search form .search-submit .open > .dropdown-toggle.focus.form-submit {
+    .btn-danger:active:hover, .btn-danger:active:focus, .btn-danger:active.focus, .btn-danger.active:hover, .btn-danger.active:focus, .btn-danger.active.focus, .open > .btn-danger.dropdown-toggle:hover, .open > .btn-danger.dropdown-toggle:focus, .open > .btn-danger.dropdown-toggle.focus {
       color: #fff;
       background-color: #de0c00;
       border-color: #9c0900; }
-  .btn-danger:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active, .btn-danger.active, .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .active.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .active.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .active.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .active.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .active.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .active.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .active.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.active, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .active.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .active.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .active.form-submit, .open > .btn-danger.dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .open > .dropdown-toggle.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .open > .dropdown-toggle.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .open > .dropdown-toggle.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .open > .dropdown-toggle.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .open > button.dropdown-toggle, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .open > .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .open > .dropdown-toggle.form-submit {
+  .btn-danger:active, .btn-danger.active, .open > .btn-danger.dropdown-toggle {
     background-image: none; }
-  .btn-danger.disabled:hover, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-cancel:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .disabled.form-submit:hover,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .disabled.form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .disabled.form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-submit .disabled.form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .disabled.form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-submit .disabled.form-submit:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .disabled.form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .disabled.form-submit:hover, .btn-danger.disabled:focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.checkout-cancel:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .disabled.form-submit:focus,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .disabled.form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .disabled.form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-submit .disabled.form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .disabled.form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-submit .disabled.form-submit:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .disabled.form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .disabled.form-submit:focus, .btn-danger.disabled.focus, .page-checkout fieldset.panel-default.checkout-buttons .disabled.focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .disabled.focus.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .disabled.focus.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .disabled.focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .disabled.focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .disabled.focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .disabled.focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .disabled.focus.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.disabled.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .disabled.focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .disabled.focus.form-submit, .btn-danger[disabled]:hover, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-cancel:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit [disabled].form-submit:hover,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit [disabled].form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit [disabled].form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-submit [disabled].form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit [disabled].form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-submit [disabled].form-submit:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled]:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit [disabled].form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit [disabled].form-submit:hover, .btn-danger[disabled]:focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].checkout-cancel:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit [disabled].form-submit:focus,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit [disabled].form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit [disabled].form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-submit [disabled].form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit [disabled].form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-submit [disabled].form-submit:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled]:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit [disabled].form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit [disabled].form-submit:focus, .btn-danger[disabled].focus, .page-checkout fieldset.panel-default.checkout-buttons [disabled].focus.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons [disabled].focus.checkout-cancel, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit [disabled].focus.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit [disabled].focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit [disabled].focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit [disabled].focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit [disabled].focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit [disabled].focus.form-submit, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button[disabled].focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit [disabled].focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit [disabled].focus.form-submit, fieldset[disabled] .btn-danger:hover, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-back:hover,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-cancel:hover, fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:hover,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] #property-bat-facets-availability .form-wrapper .search-submit .form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-submit fieldset[disabled] .form-submit:hover, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button:hover, fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit fieldset[disabled] .form-submit:hover,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit fieldset[disabled] .form-submit:hover, fieldset[disabled] .btn-danger:focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-back:focus,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .checkout-cancel:focus, fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:focus,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] #property-bat-facets-availability .form-wrapper .search-submit .form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-submit fieldset[disabled] .form-submit:focus, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button:focus, fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit fieldset[disabled] .form-submit:focus,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit fieldset[disabled] .form-submit:focus, fieldset[disabled] .btn-danger.focus, fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-back, .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .focus.checkout-back,
-  fieldset[disabled] .page-checkout fieldset.panel-default.checkout-buttons .focus.checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons fieldset[disabled] .focus.checkout-cancel, fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .focus.form-submit, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-submit .focus.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] #roomify-property-search-block-form .form-wrapper .search-availability-submit .focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] #roomify-property-search-block-form .form-wrapper .search-submit .focus.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] #property-bat-facets-availability .form-wrapper .search-availability-submit .focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] #property-bat-facets-availability .form-wrapper .search-submit .focus.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit fieldset[disabled] .focus.form-submit, fieldset[disabled] .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit fieldset[disabled] button.focus, fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .focus.form-submit, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit fieldset[disabled] .focus.form-submit,
-  fieldset[disabled] body.page-single-property-listing .pane-locanda-availability-search form .search-submit .focus.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit fieldset[disabled] .focus.form-submit {
+  .btn-danger.disabled:hover, .btn-danger.disabled:focus, .btn-danger.disabled.focus, .btn-danger[disabled]:hover, .btn-danger[disabled]:focus, .btn-danger[disabled].focus, fieldset[disabled] .btn-danger:hover, fieldset[disabled] .btn-danger:focus, fieldset[disabled] .btn-danger.focus {
     background-color: #FF4136;
     border-color: #ff291d; }
-  .btn-danger .badge, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back .badge,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel .badge, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit .badge,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit .badge,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit .badge,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit .badge,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit .badge,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit .badge, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button .badge, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit .badge,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit .badge,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit .badge,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit .badge,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit .badge,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit .badge,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit .badge,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit .badge {
+  .btn-danger .badge {
     color: #FF4136;
     background-color: #fff; }
 
@@ -3966,25 +3337,19 @@ body.page-single-property-listing .pane-locanda-availability-search form .search
     color: #999999;
     text-decoration: none; }
 
-.btn-lg, .btn-group-lg > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-cancel, .page-blog .pager-load-more .btn-group-lg > a,
-.page-blog .btn-group-lg > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-lg > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-lg > button {
+.btn-lg, .btn-group-lg > .btn {
   padding: 13px 16px;
   font-size: 19px;
   line-height: 1.33333;
   border-radius: 5px; }
 
-.btn-sm, .btn-group-sm > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-cancel, .page-blog .pager-load-more .btn-group-sm > a,
-.page-blog .btn-group-sm > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-sm > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-sm > button {
+.btn-sm, .btn-group-sm > .btn {
   padding: 4px 10px;
   font-size: 13px;
   line-height: 1.5;
   border-radius: 2px; }
 
-.btn-xs, .btn-group-xs > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-cancel, .page-blog .pager-load-more .btn-group-xs > a,
-.page-blog .btn-group-xs > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button {
+.btn-xs, .btn-group-xs > .btn {
   padding: 1px 5px;
   font-size: 13px;
   line-height: 1.5;
@@ -4164,182 +3529,20 @@ tbody.collapse.in {
   position: relative;
   display: inline-block;
   vertical-align: middle; }
-  .btn-group > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel, .page-blog .pager-load-more .btn-group > a,
-  .page-blog .btn-group > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button,
-  .btn-group-vertical > .btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel,
-  .page-blog .pager-load-more .btn-group-vertical > a,
-  .page-blog .btn-group-vertical > .roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button {
+  .btn-group > .btn,
+  .btn-group-vertical > .btn {
     position: relative;
     float: left; }
-    .btn-group > .btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:hover, .page-blog .pager-load-more .btn-group > a:hover,
-    .page-blog .btn-group > .roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:hover, .btn-group > .btn:focus, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:focus, .page-blog .pager-load-more .btn-group > a:focus,
-    .page-blog .btn-group > .roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:focus, .btn-group > .btn:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:active,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:active, .page-blog .pager-load-more .btn-group > a:active,
-    .page-blog .btn-group > .roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:active, .btn-group > .btn.active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .active.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .active.checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .active.checkout-cancel, .page-blog .pager-load-more .btn-group > a.active,
-    .page-blog .btn-group > .active.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a.active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button.active,
+    .btn-group > .btn:hover, .btn-group > .btn:focus, .btn-group > .btn:active, .btn-group > .btn.active,
     .btn-group-vertical > .btn:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel:hover,
-    .page-blog .pager-load-more .btn-group-vertical > a:hover,
-    .page-blog .btn-group-vertical > .roomify-add-button:hover,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a:hover,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button:hover,
     .btn-group-vertical > .btn:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel:focus,
-    .page-blog .pager-load-more .btn-group-vertical > a:focus,
-    .page-blog .btn-group-vertical > .roomify-add-button:focus,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a:focus,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button:focus,
     .btn-group-vertical > .btn:active,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue:active,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back:active,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel:active,
-    .page-blog .pager-load-more .btn-group-vertical > a:active,
-    .page-blog .btn-group-vertical > .roomify-add-button:active,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a:active,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button:active,
-    .btn-group-vertical > .btn.active,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .active.checkout-continue,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .active.checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .active.checkout-cancel,
-    .page-blog .pager-load-more .btn-group-vertical > a.active,
-    .page-blog .btn-group-vertical > .active.roomify-add-button,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a.active,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button.active {
+    .btn-group-vertical > .btn.active {
       z-index: 2; }
 
-.btn-group .btn + .btn, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + .btn, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + .btn,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + .btn, .btn-group .page-blog .pager-load-more a + .btn, .page-blog .pager-load-more .btn-group a + .btn,
-.btn-group .page-blog .roomify-add-button + .btn,
-.page-blog .btn-group .roomify-add-button + .btn, .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .btn, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + .btn, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + .btn, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .btn + .checkout-continue, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + .checkout-continue, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + .checkout-continue,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + .checkout-continue, .btn-group .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .pager-load-more a + .checkout-continue, .page-blog .pager-load-more .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group a + .checkout-continue,
-.btn-group .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .roomify-add-button + .checkout-continue,
-.page-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group .roomify-add-button + .checkout-continue, .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-continue, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + .checkout-continue, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-continue, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + .checkout-continue, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .btn + .checkout-back, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + .checkout-back, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + .checkout-back,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + .checkout-back, .btn-group .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .pager-load-more a + .checkout-back, .page-blog .pager-load-more .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group a + .checkout-back,
-.btn-group .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .roomify-add-button + .checkout-back,
-.page-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group .roomify-add-button + .checkout-back, .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-back, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + .checkout-back, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-back, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + .checkout-back,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .btn + .checkout-cancel,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + .checkout-cancel,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + .checkout-cancel,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + .checkout-cancel,
-.btn-group .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .pager-load-more a + .checkout-cancel,
-.page-blog .pager-load-more .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group a + .checkout-cancel,
-.btn-group .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .roomify-add-button + .checkout-cancel,
-.page-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group .roomify-add-button + .checkout-cancel,
-.btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-cancel,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + .checkout-cancel,
-.btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-cancel,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + .checkout-cancel, .btn-group .page-blog .pager-load-more .btn + a, .page-blog .pager-load-more .btn-group .btn + a, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-continue + a, .page-blog .pager-load-more .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .pager-load-more .checkout-continue + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + a, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-back + a, .page-blog .pager-load-more .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .pager-load-more .checkout-back + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + a,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-cancel + a,
-.page-blog .pager-load-more .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .pager-load-more .checkout-cancel + a,
-.page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + a, .btn-group .page-blog .pager-load-more a + a, .page-blog .pager-load-more .btn-group a + a,
-.btn-group .page-blog .pager-load-more .roomify-add-button + a,
-.page-blog .btn-group .pager-load-more .roomify-add-button + a,
-.page-blog .pager-load-more .btn-group .roomify-add-button + a, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more button + a, .page-blog .pager-load-more .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-blog .pager-load-more button + a, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + a,
-.btn-group .page-blog .btn + .roomify-add-button,
-.page-blog .btn-group .btn + .roomify-add-button,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-continue + .roomify-add-button,
-.page-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .roomify-add-button,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .checkout-continue + .roomify-add-button,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + .roomify-add-button,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-back + .roomify-add-button,
-.page-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .roomify-add-button,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .checkout-back + .roomify-add-button,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + .roomify-add-button,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-cancel + .roomify-add-button,
-.page-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .roomify-add-button,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-blog .checkout-cancel + .roomify-add-button,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + .roomify-add-button,
-.btn-group .page-blog .pager-load-more a + .roomify-add-button,
-.page-blog .pager-load-more .btn-group a + .roomify-add-button,
-.btn-group .page-blog .roomify-add-button + .roomify-add-button,
-.page-blog .btn-group .roomify-add-button + .roomify-add-button,
-.btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog a + .roomify-add-button,
-.page-blog .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-blog a + .roomify-add-button,
-.page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + .roomify-add-button,
-.btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog button + .roomify-add-button,
-.page-blog .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .roomify-add-button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-blog button + .roomify-add-button,
-.page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + .roomify-add-button, .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .btn + a, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + a, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + a,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + a,
-.btn-group .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-blog .roomify-add-button + a,
-.page-blog .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .btn-group .roomify-add-button + a, .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + a, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + a, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .btn + button, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + button, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + button, .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + button, .page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + button,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + button,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + button, .btn-group .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-blog .pager-load-more a + button, .page-blog .pager-load-more .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .btn-group a + button,
-.btn-group .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-blog .roomify-add-button + button,
-.page-blog .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .btn-group .roomify-add-button + button, .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + button, .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + button,
+.btn-group .btn + .btn,
 .btn-group .btn + .btn-group,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .btn-group,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-continue + .btn-group,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .btn-group,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-back + .btn-group,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .btn-group,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .checkout-cancel + .btn-group,
-.btn-group .page-blog .pager-load-more a + .btn-group,
-.page-blog .pager-load-more .btn-group a + .btn-group,
-.btn-group .page-blog .roomify-add-button + .btn-group,
-.page-blog .btn-group .roomify-add-button + .btn-group,
-.btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .btn-group,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group a + .btn-group,
-.btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .btn-group,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group button + .btn-group,
 .btn-group .btn-group + .btn,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn-group + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .btn-group + .checkout-continue,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn-group + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .btn-group + .checkout-back,
-.btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn-group + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group .btn-group + .checkout-cancel,
-.btn-group .page-blog .pager-load-more .btn-group + a,
-.page-blog .pager-load-more .btn-group .btn-group + a,
-.btn-group .page-blog .btn-group + .roomify-add-button,
-.page-blog .btn-group .btn-group + .roomify-add-button,
-.btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group .btn-group + a,
-.btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group .btn-group + button,
 .btn-group .btn-group + .btn-group {
   margin-left: -1px; }
 
@@ -4350,39 +3553,25 @@ tbody.collapse.in {
     display: table; }
   .btn-toolbar:after {
     clear: both; }
-  .btn-toolbar .btn, .btn-toolbar .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-toolbar .checkout-continue, .btn-toolbar .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-toolbar .checkout-back,
-  .btn-toolbar .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-toolbar .checkout-cancel, .btn-toolbar .page-blog .pager-load-more a, .page-blog .pager-load-more .btn-toolbar a,
-  .btn-toolbar .page-blog .roomify-add-button,
-  .page-blog .btn-toolbar .roomify-add-button, .btn-toolbar .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-toolbar a, .btn-toolbar .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-toolbar button,
+  .btn-toolbar .btn,
   .btn-toolbar .btn-group,
   .btn-toolbar .input-group {
     float: left; }
-  .btn-toolbar > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-toolbar > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-toolbar > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-toolbar > .checkout-cancel, .page-blog .pager-load-more .btn-toolbar > a,
-  .page-blog .btn-toolbar > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-toolbar > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-toolbar > button,
+  .btn-toolbar > .btn,
   .btn-toolbar > .btn-group,
   .btn-toolbar > .input-group {
     margin-left: 5px; }
 
-.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle), .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:not(:first-child):not(:last-child):not(.dropdown-toggle), .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:not(:first-child):not(:last-child):not(.dropdown-toggle),
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:not(:first-child):not(:last-child):not(.dropdown-toggle), .page-blog .pager-load-more .btn-group > a:not(:first-child):not(:last-child):not(.dropdown-toggle),
-.page-blog .btn-group > .roomify-add-button:not(:first-child):not(:last-child):not(.dropdown-toggle), .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:not(:first-child):not(:last-child):not(.dropdown-toggle), .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:not(:first-child):not(:last-child):not(.dropdown-toggle) {
+.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
   border-radius: 0; }
 
-.btn-group > .btn:first-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:first-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:first-child,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:first-child, .page-blog .pager-load-more .btn-group > a:first-child,
-.page-blog .btn-group > .roomify-add-button:first-child, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:first-child, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:first-child {
+.btn-group > .btn:first-child {
   margin-left: 0; }
-  .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle), .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:first-child:not(:last-child):not(.dropdown-toggle), .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:first-child:not(:last-child):not(.dropdown-toggle),
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:first-child:not(:last-child):not(.dropdown-toggle), .page-blog .pager-load-more .btn-group > a:first-child:not(:last-child):not(.dropdown-toggle),
-  .page-blog .btn-group > .roomify-add-button:first-child:not(:last-child):not(.dropdown-toggle), .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:first-child:not(:last-child):not(.dropdown-toggle), .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:first-child:not(:last-child):not(.dropdown-toggle) {
+  .btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle) {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0; }
 
-.btn-group > .btn:last-child:not(:first-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue:last-child:not(:first-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back:last-child:not(:first-child),
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel:last-child:not(:first-child), .page-blog .pager-load-more .btn-group > a:last-child:not(:first-child),
-.page-blog .btn-group > .roomify-add-button:last-child:not(:first-child), .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a:last-child:not(:first-child), .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button:last-child:not(:first-child),
+.btn-group > .btn:last-child:not(:first-child),
 .btn-group > .dropdown-toggle:not(:first-child) {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0; }
@@ -4390,21 +3579,15 @@ tbody.collapse.in {
 .btn-group > .btn-group {
   float: left; }
 
-.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:not(:first-child):not(:last-child) > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:not(:first-child):not(:last-child) > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:not(:first-child):not(:last-child) > .checkout-cancel, .page-blog .pager-load-more .btn-group > .btn-group:not(:first-child):not(:last-child) > a,
-.page-blog .btn-group > .btn-group:not(:first-child):not(:last-child) > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > .btn-group:not(:first-child):not(:last-child) > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > .btn-group:not(:first-child):not(:last-child) > button {
+.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0; }
 
-.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:first-child:not(:last-child) > .checkout-continue:last-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:first-child:not(:last-child) > .checkout-back:last-child,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:first-child:not(:last-child) > .checkout-cancel:last-child, .page-blog .pager-load-more .btn-group > .btn-group:first-child:not(:last-child) > a:last-child,
-.page-blog .btn-group > .btn-group:first-child:not(:last-child) > .roomify-add-button:last-child, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > .btn-group:first-child:not(:last-child) > a:last-child, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > .btn-group:first-child:not(:last-child) > button:last-child,
+.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child,
 .btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0; }
 
-.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:last-child:not(:first-child) > .checkout-continue:first-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:last-child:not(:first-child) > .checkout-back:first-child,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .btn-group:last-child:not(:first-child) > .checkout-cancel:first-child, .page-blog .pager-load-more .btn-group > .btn-group:last-child:not(:first-child) > a:first-child,
-.page-blog .btn-group > .btn-group:last-child:not(:first-child) > .roomify-add-button:first-child, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > .btn-group:last-child:not(:first-child) > a:first-child, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > .btn-group:last-child:not(:first-child) > button:first-child {
+.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0; }
 
@@ -4412,15 +3595,11 @@ tbody.collapse.in {
 .btn-group.open .dropdown-toggle {
   outline: 0; }
 
-.btn-group > .btn + .dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-continue + .dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-back + .dropdown-toggle,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group > .checkout-cancel + .dropdown-toggle, .page-blog .pager-load-more .btn-group > a + .dropdown-toggle,
-.page-blog .btn-group > .roomify-add-button + .dropdown-toggle, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group > a + .dropdown-toggle, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group > button + .dropdown-toggle {
+.btn-group > .btn + .dropdown-toggle {
   padding-left: 8px;
   padding-right: 8px; }
 
-.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg.btn-group > .checkout-continue + .dropdown-toggle, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg.btn-group > .checkout-back + .dropdown-toggle,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg.btn-group > .checkout-cancel + .dropdown-toggle, .page-blog .pager-load-more .btn-group-lg.btn-group > a + .dropdown-toggle,
-.page-blog .btn-group-lg.btn-group > .roomify-add-button + .dropdown-toggle, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-lg.btn-group > a + .dropdown-toggle, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-lg.btn-group > button + .dropdown-toggle {
+.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px; }
 
@@ -4431,36 +3610,19 @@ tbody.collapse.in {
     -webkit-box-shadow: none;
     box-shadow: none; }
 
-.btn .caret, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue .caret, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back .caret,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel .caret, .page-blog .pager-load-more a .caret,
-.page-blog .roomify-add-button .caret, .page-taxonomy-area .field-name-field-field-link-to-area-blog a .caret, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button .caret {
+.btn .caret {
   margin-left: 0; }
 
-.btn-lg .caret, .btn-group-lg > .btn .caret, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-continue .caret, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-back .caret,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-cancel .caret, .page-blog .pager-load-more .btn-group-lg > a .caret,
-.page-blog .btn-group-lg > .roomify-add-button .caret, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-lg > a .caret, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-lg > button .caret {
+.btn-lg .caret, .btn-group-lg > .btn .caret {
   border-width: 5px 5px 0;
   border-bottom-width: 0; }
 
-.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-continue .caret, .page-checkout fieldset.panel-default.checkout-buttons .dropup .btn-group-lg > .checkout-continue .caret, .dropup .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-back .caret, .page-checkout fieldset.panel-default.checkout-buttons .dropup .btn-group-lg > .checkout-back .caret,
-.dropup .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-cancel .caret,
-.page-checkout fieldset.panel-default.checkout-buttons .dropup .btn-group-lg > .checkout-cancel .caret, .dropup .page-blog .pager-load-more .btn-group-lg > a .caret, .page-blog .pager-load-more .dropup .btn-group-lg > a .caret,
-.dropup .page-blog .btn-group-lg > .roomify-add-button .caret,
-.page-blog .dropup .btn-group-lg > .roomify-add-button .caret, .dropup .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-lg > a .caret, .page-taxonomy-area .field-name-field-field-link-to-area-blog .dropup .btn-group-lg > a .caret, .dropup .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-lg > button .caret, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .dropup .btn-group-lg > button .caret {
+.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret {
   border-width: 0 5px 5px; }
 
-.btn-group-vertical > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel, .page-blog .pager-load-more .btn-group-vertical > a,
-.page-blog .btn-group-vertical > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button,
+.btn-group-vertical > .btn,
 .btn-group-vertical > .btn-group,
-.btn-group-vertical > .btn-group > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group > .checkout-cancel,
-.page-blog .pager-load-more .btn-group-vertical > .btn-group > a,
-.page-blog .btn-group-vertical > .btn-group > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn-group > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn-group > button {
+.btn-group-vertical > .btn-group > .btn {
   display: block;
   float: none;
   width: 100%;
@@ -4470,109 +3632,37 @@ tbody.collapse.in {
   display: table; }
 .btn-group-vertical > .btn-group:after {
   clear: both; }
-.btn-group-vertical > .btn-group > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group > .checkout-cancel, .page-blog .pager-load-more .btn-group-vertical > .btn-group > a,
-.page-blog .btn-group-vertical > .btn-group > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn-group > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn-group > button {
+.btn-group-vertical > .btn-group > .btn {
   float: none; }
-.btn-group-vertical > .btn + .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + .btn, .page-blog .pager-load-more .btn-group-vertical > a + .btn,
-.page-blog .btn-group-vertical > .roomify-add-button + .btn, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + .btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + .checkout-continue, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical > a + .checkout-continue,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .roomify-add-button + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical > .roomify-add-button + .checkout-continue, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + .checkout-continue, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + .checkout-back, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical > a + .checkout-back,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .roomify-add-button + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical > .roomify-add-button + .checkout-back, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + .checkout-back, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + .checkout-cancel,
-.page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > a + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical > a + .checkout-cancel,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .roomify-add-button + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical > .roomify-add-button + .checkout-cancel,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > a + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + .checkout-cancel,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > button + .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + .checkout-cancel, .page-blog .pager-load-more .btn-group-vertical > .btn + a, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical > .checkout-continue + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical > .checkout-back + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + a,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical > .checkout-cancel + a,
-.page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + a, .page-blog .pager-load-more .btn-group-vertical > a + a,
-.page-blog .pager-load-more .btn-group-vertical > .roomify-add-button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .btn-group-vertical > button + a, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + a,
-.page-blog .btn-group-vertical > .btn + .roomify-add-button,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical > .checkout-continue + .roomify-add-button,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + .roomify-add-button,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical > .checkout-back + .roomify-add-button,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + .roomify-add-button,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical > .checkout-cancel + .roomify-add-button,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + .roomify-add-button,
-.page-blog .pager-load-more .btn-group-vertical > a + .roomify-add-button,
-.page-blog .btn-group-vertical > .roomify-add-button + .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .btn-group-vertical > a + .roomify-add-button,
-.page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + .roomify-add-button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .btn-group-vertical > button + .roomify-add-button,
-.page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn + a, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + a,
-.page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .checkout-cancel + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + a,
-.page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .roomify-add-button + a,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .btn-group-vertical > .roomify-add-button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn + button, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + button, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + button,
-.page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .checkout-cancel + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + button, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .btn-group-vertical > a + button,
-.page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .roomify-add-button + button,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .btn-group-vertical > .roomify-add-button + button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + button,
+.btn-group-vertical > .btn + .btn,
 .btn-group-vertical > .btn + .btn-group,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue + .btn-group,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back + .btn-group,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel + .btn-group,
-.page-blog .pager-load-more .btn-group-vertical > a + .btn-group,
-.page-blog .btn-group-vertical > .roomify-add-button + .btn-group,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a + .btn-group,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button + .btn-group,
 .btn-group-vertical > .btn-group + .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group + .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group + .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group + .checkout-cancel,
-.page-blog .pager-load-more .btn-group-vertical > .btn-group + a,
-.page-blog .btn-group-vertical > .btn-group + .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn-group + a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn-group + button,
 .btn-group-vertical > .btn-group + .btn-group {
   margin-top: -1px;
   margin-left: 0; }
 
-.btn-group-vertical > .btn:not(:first-child):not(:last-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue:not(:first-child):not(:last-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back:not(:first-child):not(:last-child),
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel:not(:first-child):not(:last-child), .page-blog .pager-load-more .btn-group-vertical > a:not(:first-child):not(:last-child),
-.page-blog .btn-group-vertical > .roomify-add-button:not(:first-child):not(:last-child), .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a:not(:first-child):not(:last-child), .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button:not(:first-child):not(:last-child) {
+.btn-group-vertical > .btn:not(:first-child):not(:last-child) {
   border-radius: 0; }
-.btn-group-vertical > .btn:first-child:not(:last-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue:first-child:not(:last-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back:first-child:not(:last-child),
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel:first-child:not(:last-child), .page-blog .pager-load-more .btn-group-vertical > a:first-child:not(:last-child),
-.page-blog .btn-group-vertical > .roomify-add-button:first-child:not(:last-child), .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a:first-child:not(:last-child), .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button:first-child:not(:last-child) {
+.btn-group-vertical > .btn:first-child:not(:last-child) {
   border-top-right-radius: 4px;
   border-top-left-radius: 4px;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0; }
-.btn-group-vertical > .btn:last-child:not(:first-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-continue:last-child:not(:first-child), .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-back:last-child:not(:first-child),
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .checkout-cancel:last-child:not(:first-child), .page-blog .pager-load-more .btn-group-vertical > a:last-child:not(:first-child),
-.page-blog .btn-group-vertical > .roomify-add-button:last-child:not(:first-child), .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > a:last-child:not(:first-child), .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > button:last-child:not(:first-child) {
+.btn-group-vertical > .btn:last-child:not(:first-child) {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
   border-bottom-right-radius: 4px;
   border-bottom-left-radius: 4px; }
 
-.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .checkout-cancel, .page-blog .pager-load-more .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > a,
-.page-blog .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > button {
+.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
   border-radius: 0; }
 
-.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:first-child:not(:last-child) > .checkout-continue:last-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:first-child:not(:last-child) > .checkout-back:last-child,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:first-child:not(:last-child) > .checkout-cancel:last-child, .page-blog .pager-load-more .btn-group-vertical > .btn-group:first-child:not(:last-child) > a:last-child,
-.page-blog .btn-group-vertical > .btn-group:first-child:not(:last-child) > .roomify-add-button:last-child, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn-group:first-child:not(:last-child) > a:last-child, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn-group:first-child:not(:last-child) > button:last-child,
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child,
 .btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0; }
 
-.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:last-child:not(:first-child) > .checkout-continue:first-child, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:last-child:not(:first-child) > .checkout-back:first-child,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical > .btn-group:last-child:not(:first-child) > .checkout-cancel:first-child, .page-blog .pager-load-more .btn-group-vertical > .btn-group:last-child:not(:first-child) > a:first-child,
-.page-blog .btn-group-vertical > .btn-group:last-child:not(:first-child) > .roomify-add-button:first-child, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical > .btn-group:last-child:not(:first-child) > a:first-child, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical > .btn-group:last-child:not(:first-child) > button:first-child {
+.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
   border-top-right-radius: 0;
   border-top-left-radius: 0; }
 
@@ -4581,49 +3671,20 @@ tbody.collapse.in {
   width: 100%;
   table-layout: fixed;
   border-collapse: separate; }
-  .btn-group-justified > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-justified > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-justified > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-justified > .checkout-cancel, .page-blog .pager-load-more .btn-group-justified > a,
-  .page-blog .btn-group-justified > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-justified > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-justified > button,
+  .btn-group-justified > .btn,
   .btn-group-justified > .btn-group {
     float: none;
     display: table-cell;
     width: 1%; }
-  .btn-group-justified > .btn-group .btn, .btn-group-justified > .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-justified > .btn-group .checkout-continue, .btn-group-justified > .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-justified > .btn-group .checkout-back,
-  .btn-group-justified > .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-justified > .btn-group .checkout-cancel, .btn-group-justified > .btn-group .page-blog .pager-load-more a, .page-blog .pager-load-more .btn-group-justified > .btn-group a,
-  .btn-group-justified > .btn-group .page-blog .roomify-add-button,
-  .page-blog .btn-group-justified > .btn-group .roomify-add-button, .btn-group-justified > .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-justified > .btn-group a, .btn-group-justified > .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-justified > .btn-group button {
+  .btn-group-justified > .btn-group .btn {
     width: 100%; }
   .btn-group-justified > .btn-group .dropdown-menu {
     left: auto; }
 
-[data-toggle="buttons"] > .btn input[type="radio"], .page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .checkout-continue input[type="radio"], .page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .checkout-back input[type="radio"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .checkout-cancel input[type="radio"], .page-blog .pager-load-more [data-toggle="buttons"] > a input[type="radio"],
-.page-blog [data-toggle="buttons"] > .roomify-add-button input[type="radio"], .page-taxonomy-area .field-name-field-field-link-to-area-blog [data-toggle="buttons"] > a input[type="radio"], .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit [data-toggle="buttons"] > button input[type="radio"],
+[data-toggle="buttons"] > .btn input[type="radio"],
 [data-toggle="buttons"] > .btn input[type="checkbox"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .checkout-continue input[type="checkbox"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .checkout-back input[type="checkbox"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .checkout-cancel input[type="checkbox"],
-.page-blog .pager-load-more [data-toggle="buttons"] > a input[type="checkbox"],
-.page-blog [data-toggle="buttons"] > .roomify-add-button input[type="checkbox"],
-.page-taxonomy-area .field-name-field-field-link-to-area-blog [data-toggle="buttons"] > a input[type="checkbox"],
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit [data-toggle="buttons"] > button input[type="checkbox"],
 [data-toggle="buttons"] > .btn-group > .btn input[type="radio"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .btn-group > .checkout-continue input[type="radio"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .btn-group > .checkout-back input[type="radio"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .btn-group > .checkout-cancel input[type="radio"],
-.page-blog .pager-load-more [data-toggle="buttons"] > .btn-group > a input[type="radio"],
-.page-blog [data-toggle="buttons"] > .btn-group > .roomify-add-button input[type="radio"],
-.page-taxonomy-area .field-name-field-field-link-to-area-blog [data-toggle="buttons"] > .btn-group > a input[type="radio"],
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit [data-toggle="buttons"] > .btn-group > button input[type="radio"],
-[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .btn-group > .checkout-continue input[type="checkbox"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .btn-group > .checkout-back input[type="checkbox"],
-.page-checkout fieldset.panel-default.checkout-buttons [data-toggle="buttons"] > .btn-group > .checkout-cancel input[type="checkbox"],
-.page-blog .pager-load-more [data-toggle="buttons"] > .btn-group > a input[type="checkbox"],
-.page-blog [data-toggle="buttons"] > .btn-group > .roomify-add-button input[type="checkbox"],
-.page-taxonomy-area .field-name-field-field-link-to-area-blog [data-toggle="buttons"] > .btn-group > a input[type="checkbox"],
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit [data-toggle="buttons"] > .btn-group > button input[type="checkbox"] {
+[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"] {
   position: absolute;
   clip: rect(0, 0, 0, 0);
   pointer-events: none; }
@@ -4672,27 +3733,13 @@ tbody.collapse.in {
   border-radius: 4px; }
   .input-group-addon.input-sm,
   .input-group-sm > .input-group-addon,
-  .input-group-sm > .input-group-btn > .input-group-addon.btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .input-group-addon.checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .input-group-addon.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-sm > .input-group-btn > .input-group-addon.checkout-cancel,
-  .page-blog .pager-load-more .input-group-sm > .input-group-btn > a.input-group-addon,
-  .page-blog .input-group-sm > .input-group-btn > .input-group-addon.roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-sm > .input-group-btn > a.input-group-addon,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-sm > .input-group-btn > button.input-group-addon {
+  .input-group-sm > .input-group-btn > .input-group-addon.btn {
     padding: 4px 10px;
     font-size: 13px;
     border-radius: 2px; }
   .input-group-addon.input-lg,
   .input-group-lg > .input-group-addon,
-  .input-group-lg > .input-group-btn > .input-group-addon.btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .input-group-addon.checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .input-group-addon.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-lg > .input-group-btn > .input-group-addon.checkout-cancel,
-  .page-blog .pager-load-more .input-group-lg > .input-group-btn > a.input-group-addon,
-  .page-blog .input-group-lg > .input-group-btn > .input-group-addon.roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-lg > .input-group-btn > a.input-group-addon,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-lg > .input-group-btn > button.input-group-addon {
+  .input-group-lg > .input-group-btn > .input-group-addon.btn {
     padding: 13px 16px;
     font-size: 19px;
     border-radius: 5px; }
@@ -4703,38 +3750,10 @@ tbody.collapse.in {
 .input-group .form-control:first-child,
 .input-group-addon:first-child,
 .input-group-btn:first-child > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-cancel,
-.page-blog .pager-load-more .input-group-btn:first-child > a,
-.page-blog .input-group-btn:first-child > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:first-child > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:first-child > button,
 .input-group-btn:first-child > .btn-group > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .btn-group > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .btn-group > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .btn-group > .checkout-cancel,
-.page-blog .pager-load-more .input-group-btn:first-child > .btn-group > a,
-.page-blog .input-group-btn:first-child > .btn-group > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:first-child > .btn-group > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:first-child > .btn-group > button,
 .input-group-btn:first-child > .dropdown-toggle,
 .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-continue:not(:last-child):not(.dropdown-toggle),
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-back:not(:last-child):not(.dropdown-toggle),
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-cancel:not(:last-child):not(.dropdown-toggle),
-.page-blog .pager-load-more .input-group-btn:last-child > a:not(:last-child):not(.dropdown-toggle),
-.page-blog .input-group-btn:last-child > .roomify-add-button:not(:last-child):not(.dropdown-toggle),
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:last-child > a:not(:last-child):not(.dropdown-toggle),
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:last-child > button:not(:last-child):not(.dropdown-toggle),
-.input-group-btn:last-child > .btn-group:not(:last-child) > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .btn-group:not(:last-child) > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .btn-group:not(:last-child) > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .btn-group:not(:last-child) > .checkout-cancel,
-.page-blog .pager-load-more .input-group-btn:last-child > .btn-group:not(:last-child) > a,
-.page-blog .input-group-btn:last-child > .btn-group:not(:last-child) > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:last-child > .btn-group:not(:last-child) > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:last-child > .btn-group:not(:last-child) > button {
+.input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0; }
 
@@ -4744,38 +3763,10 @@ tbody.collapse.in {
 .input-group .form-control:last-child,
 .input-group-addon:last-child,
 .input-group-btn:last-child > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-cancel,
-.page-blog .pager-load-more .input-group-btn:last-child > a,
-.page-blog .input-group-btn:last-child > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:last-child > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:last-child > button,
 .input-group-btn:last-child > .btn-group > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .btn-group > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .btn-group > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .btn-group > .checkout-cancel,
-.page-blog .pager-load-more .input-group-btn:last-child > .btn-group > a,
-.page-blog .input-group-btn:last-child > .btn-group > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:last-child > .btn-group > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:last-child > .btn-group > button,
 .input-group-btn:last-child > .dropdown-toggle,
 .input-group-btn:first-child > .btn:not(:first-child),
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-continue:not(:first-child),
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-back:not(:first-child),
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-cancel:not(:first-child),
-.page-blog .pager-load-more .input-group-btn:first-child > a:not(:first-child),
-.page-blog .input-group-btn:first-child > .roomify-add-button:not(:first-child),
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:first-child > a:not(:first-child),
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:first-child > button:not(:first-child),
-.input-group-btn:first-child > .btn-group:not(:first-child) > .btn,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .btn-group:not(:first-child) > .checkout-continue,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .btn-group:not(:first-child) > .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .btn-group:not(:first-child) > .checkout-cancel,
-.page-blog .pager-load-more .input-group-btn:first-child > .btn-group:not(:first-child) > a,
-.page-blog .input-group-btn:first-child > .btn-group:not(:first-child) > .roomify-add-button,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:first-child > .btn-group:not(:first-child) > a,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:first-child > .btn-group:not(:first-child) > button {
+.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0; }
 
@@ -4786,72 +3777,16 @@ tbody.collapse.in {
   position: relative;
   font-size: 0;
   white-space: nowrap; }
-  .input-group-btn > .btn, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel, .page-blog .pager-load-more .input-group-btn > a,
-  .page-blog .input-group-btn > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button {
+  .input-group-btn > .btn {
     position: relative; }
-    .input-group-btn > .btn + .btn, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + .btn, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + .btn,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + .btn, .page-blog .pager-load-more .input-group-btn > a + .btn,
-    .page-blog .input-group-btn > .roomify-add-button + .btn, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + .btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + .btn, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .btn + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + .checkout-continue,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + .checkout-continue, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .input-group-btn > a + .checkout-continue,
-    .page-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .roomify-add-button + .checkout-continue,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .input-group-btn > .roomify-add-button + .checkout-continue, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + .checkout-continue, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .btn + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + .checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + .checkout-back, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .input-group-btn > a + .checkout-back,
-    .page-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .roomify-add-button + .checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .input-group-btn > .roomify-add-button + .checkout-back, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + .checkout-back, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + .checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .btn + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + .checkout-cancel,
-    .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > a + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .input-group-btn > a + .checkout-cancel,
-    .page-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .roomify-add-button + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .input-group-btn > .roomify-add-button + .checkout-cancel,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > a + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + .checkout-cancel,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > button + .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + .checkout-cancel, .page-blog .pager-load-more .input-group-btn > .btn + a, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .input-group-btn > .checkout-continue + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .input-group-btn > .checkout-back + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + a,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .input-group-btn > .checkout-cancel + a,
-    .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + a, .page-blog .pager-load-more .input-group-btn > a + a,
-    .page-blog .pager-load-more .input-group-btn > .roomify-add-button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .input-group-btn > button + a, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + a,
-    .page-blog .input-group-btn > .btn + .roomify-add-button,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .input-group-btn > .checkout-continue + .roomify-add-button,
-    .page-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + .roomify-add-button,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .input-group-btn > .checkout-back + .roomify-add-button,
-    .page-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + .roomify-add-button,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .input-group-btn > .checkout-cancel + .roomify-add-button,
-    .page-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + .roomify-add-button,
-    .page-blog .pager-load-more .input-group-btn > a + .roomify-add-button,
-    .page-blog .input-group-btn > .roomify-add-button + .roomify-add-button,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .input-group-btn > a + .roomify-add-button,
-    .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + .roomify-add-button,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .input-group-btn > button + .roomify-add-button,
-    .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > .btn + a, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + a,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > .checkout-cancel + a,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + a,
-    .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > .roomify-add-button + a,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .input-group-btn > .roomify-add-button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > .btn + button, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue + button, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back + button,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > .checkout-cancel + button,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel + button, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .input-group-btn > a + button,
-    .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > .roomify-add-button + button,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .input-group-btn > .roomify-add-button + button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button + button {
+    .input-group-btn > .btn + .btn {
       margin-left: -1px; }
-    .input-group-btn > .btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back:hover,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel:hover, .page-blog .pager-load-more .input-group-btn > a:hover,
-    .page-blog .input-group-btn > .roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button:hover, .input-group-btn > .btn:focus, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back:focus,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel:focus, .page-blog .pager-load-more .input-group-btn > a:focus,
-    .page-blog .input-group-btn > .roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button:focus, .input-group-btn > .btn:active, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-back:active,
-    .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn > .checkout-cancel:active, .page-blog .pager-load-more .input-group-btn > a:active,
-    .page-blog .input-group-btn > .roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn > a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn > button:active {
+    .input-group-btn > .btn:hover, .input-group-btn > .btn:focus, .input-group-btn > .btn:active {
       z-index: 2; }
-  .input-group-btn:first-child > .btn, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:first-child > .checkout-cancel, .page-blog .pager-load-more .input-group-btn:first-child > a,
-  .page-blog .input-group-btn:first-child > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:first-child > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:first-child > button,
+  .input-group-btn:first-child > .btn,
   .input-group-btn:first-child > .btn-group {
     margin-right: -1px; }
-  .input-group-btn:last-child > .btn, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .input-group-btn:last-child > .checkout-cancel, .page-blog .pager-load-more .input-group-btn:last-child > a,
-  .page-blog .input-group-btn:last-child > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .input-group-btn:last-child > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .input-group-btn:last-child > button,
+  .input-group-btn:last-child > .btn,
   .input-group-btn:last-child > .btn-group {
     z-index: 2;
     margin-left: -1px; }
@@ -5038,25 +3973,15 @@ tbody.collapse.in {
     .navbar-fixed-bottom .navbar-collapse {
       max-height: 200px; } }
 
-.container > .navbar-header, .messages-container > .navbar-header, .page-taxonomy-area .panel_sl_content > .navbar-header, body.page-single-property-listing .panel-content-wrapper > .navbar-header,
-body.page-single-property-listing .panel-content-bottom > .navbar-header,
+.container > .navbar-header,
 .container > .navbar-collapse,
-.messages-container > .navbar-collapse,
-.page-taxonomy-area .panel_sl_content > .navbar-collapse,
-body.page-single-property-listing .panel-content-wrapper > .navbar-collapse,
-body.page-single-property-listing .panel-content-bottom > .navbar-collapse,
 .container-fluid > .navbar-header,
 .container-fluid > .navbar-collapse {
   margin-right: -15px;
   margin-left: -15px; }
   @media (min-width: 768px) {
-    .container > .navbar-header, .messages-container > .navbar-header, .page-taxonomy-area .panel_sl_content > .navbar-header, body.page-single-property-listing .panel-content-wrapper > .navbar-header,
-    body.page-single-property-listing .panel-content-bottom > .navbar-header,
+    .container > .navbar-header,
     .container > .navbar-collapse,
-    .messages-container > .navbar-collapse,
-    .page-taxonomy-area .panel_sl_content > .navbar-collapse,
-    body.page-single-property-listing .panel-content-wrapper > .navbar-collapse,
-    body.page-single-property-listing .panel-content-bottom > .navbar-collapse,
     .container-fluid > .navbar-header,
     .container-fluid > .navbar-collapse {
       margin-right: 0;
@@ -5100,8 +4025,7 @@ body.page-single-property-listing .panel-content-bottom > .navbar-collapse,
   .navbar-brand > img {
     display: block; }
   @media (min-width: 768px) {
-    .navbar > .container .navbar-brand, .navbar > .messages-container .navbar-brand, .page-taxonomy-area .navbar > .panel_sl_content .navbar-brand, body.page-single-property-listing .navbar > .panel-content-wrapper .navbar-brand,
-    body.page-single-property-listing .navbar > .panel-content-bottom .navbar-brand, .navbar > .container-fluid .navbar-brand {
+    .navbar > .container .navbar-brand, .navbar > .container-fluid .navbar-brand {
       margin-left: -15px; } }
 
 .navbar-toggle {
@@ -5239,14 +4163,10 @@ body.page-single-property-listing .panel-content-bottom > .navbar-collapse,
 .navbar-btn {
   margin-top: 5.5px;
   margin-bottom: 5.5px; }
-  .navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-cancel, .page-blog .pager-load-more .btn-group-sm > a.navbar-btn,
-  .page-blog .btn-group-sm > .navbar-btn.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-sm > a.navbar-btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-sm > button.navbar-btn {
+  .navbar-btn.btn-sm, .btn-group-sm > .navbar-btn.btn {
     margin-top: 10.5px;
     margin-bottom: 10.5px; }
-  .navbar-btn.btn-xs, .btn-group-xs > .navbar-btn.btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-cancel, .page-blog .pager-load-more .btn-group-xs > a.navbar-btn,
-  .page-blog .btn-group-xs > .navbar-btn.roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a.navbar-btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button.navbar-btn {
+  .navbar-btn.btn-xs, .btn-group-xs > .navbar-btn.btn {
     margin-top: 14px;
     margin-bottom: 14px; }
 
@@ -5531,9 +4451,7 @@ body.page-single-property-listing .panel-content-bottom > .navbar-collapse,
   border-radius: .25em; }
   .label:empty {
     display: none; }
-  .btn .label, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue .label, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back .label,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel .label, .page-blog .pager-load-more a .label,
-  .page-blog .roomify-add-button .label, .page-taxonomy-area .field-name-field-field-link-to-area-blog a .label, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button .label {
+  .btn .label {
     position: relative;
     top: -1px; }
 
@@ -5587,16 +4505,10 @@ a.label:hover, a.label:focus {
   border-radius: 10px; }
   .badge:empty {
     display: none; }
-  .btn .badge, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue .badge, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back .badge,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel .badge, .page-blog .pager-load-more a .badge,
-  .page-blog .roomify-add-button .badge, .page-taxonomy-area .field-name-field-field-link-to-area-blog a .badge, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button .badge {
+  .btn .badge {
     position: relative;
     top: -1px; }
-  .btn-xs .badge, .btn-group-xs > .btn .badge, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-continue .badge, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-back .badge,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-cancel .badge, .page-blog .pager-load-more .btn-group-xs > a .badge,
-  .page-blog .btn-group-xs > .roomify-add-button .badge, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a .badge, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button .badge, .btn-group-xs > .btn .badge, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-continue .badge, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-back .badge,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-cancel .badge, .page-blog .pager-load-more .btn-group-xs > a .badge,
-  .page-blog .btn-group-xs > .roomify-add-button .badge, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a .badge, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button .badge {
+  .btn-xs .badge, .btn-group-xs > .btn .badge, .btn-group-xs > .btn .badge {
     top: 0;
     padding: 1px 5px; }
   .list-group-item.active > .badge, .nav-pills > .active > a > .badge {
@@ -5629,21 +4541,17 @@ a.badge:hover, a.badge:focus {
     font-weight: 200; }
   .jumbotron > hr {
     border-top-color: #e1e1e1; }
-  .container .jumbotron, .messages-container .jumbotron, .page-taxonomy-area .panel_sl_content .jumbotron, body.page-single-property-listing .panel-content-wrapper .jumbotron,
-  body.page-single-property-listing .panel-content-bottom .jumbotron, .container-fluid .jumbotron {
+  .container .jumbotron, .container-fluid .jumbotron {
     border-radius: 5px;
     padding-left: 15px;
     padding-right: 15px; }
-  .jumbotron .container, .jumbotron .messages-container, .jumbotron .page-taxonomy-area .panel_sl_content, .page-taxonomy-area .jumbotron .panel_sl_content, .jumbotron body.page-single-property-listing .panel-content-wrapper, body.page-single-property-listing .jumbotron .panel-content-wrapper,
-  .jumbotron body.page-single-property-listing .panel-content-bottom,
-  body.page-single-property-listing .jumbotron .panel-content-bottom {
+  .jumbotron .container {
     max-width: 100%; }
   @media screen and (min-width: 768px) {
     .jumbotron {
       padding-top: 48px;
       padding-bottom: 48px; }
-      .container .jumbotron, .messages-container .jumbotron, .page-taxonomy-area .panel_sl_content .jumbotron, body.page-single-property-listing .panel-content-wrapper .jumbotron,
-      body.page-single-property-listing .panel-content-bottom .jumbotron, .container-fluid .jumbotron {
+      .container .jumbotron, .container-fluid .jumbotron {
         padding-left: 60px;
         padding-right: 60px; }
       .jumbotron h1,
@@ -6479,188 +5387,10 @@ button.close {
     display: table; }
   .modal-footer:after {
     clear: both; }
-  .modal-footer .btn + .btn, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .btn, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + .btn, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .btn, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + .btn,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + .btn, .modal-footer .page-blog .pager-load-more a + .btn, .page-blog .pager-load-more .modal-footer a + .btn,
-  .modal-footer .page-blog .roomify-add-button + .btn,
-  .page-blog .modal-footer .roomify-add-button + .btn, .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .btn, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + .btn, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + .btn, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn + .checkout-continue, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + .checkout-continue, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + .checkout-continue,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + .checkout-continue, .modal-footer .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .pager-load-more a + .checkout-continue, .page-blog .pager-load-more .modal-footer .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .modal-footer a + .checkout-continue,
-  .modal-footer .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .roomify-add-button + .checkout-continue,
-  .page-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .modal-footer .roomify-add-button + .checkout-continue, .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-continue, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + .checkout-continue, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-continue, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + .checkout-continue, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn + .checkout-back, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + .checkout-back, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + .checkout-back,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + .checkout-back, .modal-footer .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .pager-load-more a + .checkout-back, .page-blog .pager-load-more .modal-footer .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .modal-footer a + .checkout-back,
-  .modal-footer .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .roomify-add-button + .checkout-back,
-  .page-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .modal-footer .roomify-add-button + .checkout-back, .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-back, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + .checkout-back, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-back, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + .checkout-back,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn + .checkout-cancel,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + .checkout-cancel,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + .checkout-cancel,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + .checkout-cancel,
-  .modal-footer .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .pager-load-more a + .checkout-cancel,
-  .page-blog .pager-load-more .modal-footer .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .modal-footer a + .checkout-cancel,
-  .modal-footer .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .roomify-add-button + .checkout-cancel,
-  .page-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .modal-footer .roomify-add-button + .checkout-cancel,
-  .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-cancel,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + .checkout-cancel,
-  .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-cancel,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + .checkout-cancel, .modal-footer .page-blog .pager-load-more .btn + a, .page-blog .pager-load-more .modal-footer .btn + a, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-continue + a, .page-blog .pager-load-more .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .pager-load-more .checkout-continue + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + a, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-back + a, .page-blog .pager-load-more .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .pager-load-more .checkout-back + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + a,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-cancel + a,
-  .page-blog .pager-load-more .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .pager-load-more .checkout-cancel + a,
-  .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + a, .modal-footer .page-blog .pager-load-more a + a, .page-blog .pager-load-more .modal-footer a + a,
-  .modal-footer .page-blog .pager-load-more .roomify-add-button + a,
-  .page-blog .modal-footer .pager-load-more .roomify-add-button + a,
-  .page-blog .pager-load-more .modal-footer .roomify-add-button + a, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more button + a, .page-blog .pager-load-more .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-blog .pager-load-more button + a, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + a,
-  .modal-footer .page-blog .btn + .roomify-add-button,
-  .page-blog .modal-footer .btn + .roomify-add-button,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-continue + .roomify-add-button,
-  .page-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .roomify-add-button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .checkout-continue + .roomify-add-button,
-  .page-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + .roomify-add-button,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-back + .roomify-add-button,
-  .page-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .roomify-add-button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .checkout-back + .roomify-add-button,
-  .page-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + .roomify-add-button,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-cancel + .roomify-add-button,
-  .page-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .roomify-add-button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-blog .checkout-cancel + .roomify-add-button,
-  .page-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + .roomify-add-button,
-  .modal-footer .page-blog .pager-load-more a + .roomify-add-button,
-  .page-blog .pager-load-more .modal-footer a + .roomify-add-button,
-  .modal-footer .page-blog .roomify-add-button + .roomify-add-button,
-  .page-blog .modal-footer .roomify-add-button + .roomify-add-button,
-  .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog a + .roomify-add-button,
-  .page-blog .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-blog a + .roomify-add-button,
-  .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + .roomify-add-button,
-  .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog button + .roomify-add-button,
-  .page-blog .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .roomify-add-button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-blog button + .roomify-add-button,
-  .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + .roomify-add-button, .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn + a, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + a, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + a,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + a,
-  .modal-footer .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-blog .roomify-add-button + a,
-  .page-blog .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .modal-footer .roomify-add-button + a, .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + a, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + a, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn + button, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + button, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-continue + button, .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + button, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-back + button,
-  .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .checkout-cancel + button, .modal-footer .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-blog .pager-load-more a + button, .page-blog .pager-load-more .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .modal-footer a + button,
-  .modal-footer .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-blog .roomify-add-button + button,
-  .page-blog .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .modal-footer .roomify-add-button + button, .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .page-taxonomy-area .field-name-field-field-link-to-area-blog a + button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer a + button, .modal-footer .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer button + button {
+  .modal-footer .btn + .btn {
     margin-left: 5px;
     margin-bottom: 0; }
-  .modal-footer .btn-group .btn + .btn, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .btn, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + .btn, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .btn, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + .btn,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .btn,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + .btn, .modal-footer .btn-group .page-blog .pager-load-more a + .btn, .page-blog .pager-load-more .modal-footer .btn-group a + .btn,
-  .modal-footer .btn-group .page-blog .roomify-add-button + .btn,
-  .page-blog .modal-footer .btn-group .roomify-add-button + .btn, .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .btn, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + .btn, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .btn, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + .btn, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .btn + .checkout-continue, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + .checkout-continue, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + .checkout-continue,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + .checkout-continue, .modal-footer .btn-group .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .pager-load-more a + .checkout-continue, .page-blog .pager-load-more .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .modal-footer .btn-group a + .checkout-continue,
-  .modal-footer .btn-group .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .roomify-add-button + .checkout-continue,
-  .page-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .modal-footer .btn-group .roomify-add-button + .checkout-continue, .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-continue, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + .checkout-continue, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-continue, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + .checkout-continue, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .btn + .checkout-back, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + .checkout-back, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + .checkout-back,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + .checkout-back, .modal-footer .btn-group .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .pager-load-more a + .checkout-back, .page-blog .pager-load-more .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .modal-footer .btn-group a + .checkout-back,
-  .modal-footer .btn-group .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .roomify-add-button + .checkout-back,
-  .page-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .modal-footer .btn-group .roomify-add-button + .checkout-back, .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-back, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + .checkout-back, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-back, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + .checkout-back,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .btn + .checkout-cancel,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + .checkout-cancel,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + .checkout-cancel,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + .checkout-cancel,
-  .modal-footer .btn-group .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .pager-load-more a + .checkout-cancel,
-  .page-blog .pager-load-more .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .modal-footer .btn-group a + .checkout-cancel,
-  .modal-footer .btn-group .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .roomify-add-button + .checkout-cancel,
-  .page-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-blog .modal-footer .btn-group .roomify-add-button + .checkout-cancel,
-  .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-cancel,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + .checkout-cancel,
-  .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-cancel,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + .checkout-cancel, .modal-footer .btn-group .page-blog .pager-load-more .btn + a, .page-blog .pager-load-more .modal-footer .btn-group .btn + a, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-continue + a, .page-blog .pager-load-more .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .pager-load-more .checkout-continue + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + a, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-back + a, .page-blog .pager-load-more .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .pager-load-more .checkout-back + a, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + a,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-cancel + a,
-  .page-blog .pager-load-more .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .pager-load-more .checkout-cancel + a,
-  .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + a, .modal-footer .btn-group .page-blog .pager-load-more a + a, .page-blog .pager-load-more .modal-footer .btn-group a + a,
-  .modal-footer .btn-group .page-blog .pager-load-more .roomify-add-button + a,
-  .page-blog .modal-footer .btn-group .pager-load-more .roomify-add-button + a,
-  .page-blog .pager-load-more .modal-footer .btn-group .roomify-add-button + a, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more button + a, .page-blog .pager-load-more .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-blog .pager-load-more button + a, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + a,
-  .modal-footer .btn-group .page-blog .btn + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .btn + .roomify-add-button,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-continue + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .roomify-add-button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .checkout-continue + .roomify-add-button,
-  .page-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + .roomify-add-button,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-back + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .roomify-add-button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .checkout-back + .roomify-add-button,
-  .page-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + .roomify-add-button,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-cancel + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .roomify-add-button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-blog .checkout-cancel + .roomify-add-button,
-  .page-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + .roomify-add-button,
-  .modal-footer .btn-group .page-blog .pager-load-more a + .roomify-add-button,
-  .page-blog .pager-load-more .modal-footer .btn-group a + .roomify-add-button,
-  .modal-footer .btn-group .page-blog .roomify-add-button + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .roomify-add-button + .roomify-add-button,
-  .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog a + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .roomify-add-button,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-blog a + .roomify-add-button,
-  .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + .roomify-add-button,
-  .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog button + .roomify-add-button,
-  .page-blog .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .roomify-add-button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-blog button + .roomify-add-button,
-  .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + .roomify-add-button, .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .btn + a, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + a, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + a,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + a,
-  .modal-footer .btn-group .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-blog .roomify-add-button + a,
-  .page-blog .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a,
-  .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .modal-footer .btn-group .roomify-add-button + a, .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + a, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + a, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .btn + button, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + button, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-continue + button, .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + button, .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-back + button,
-  .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + button,
-  .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .modal-footer .btn-group .checkout-cancel + button, .modal-footer .btn-group .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-blog .pager-load-more a + button, .page-blog .pager-load-more .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .modal-footer .btn-group a + button,
-  .modal-footer .btn-group .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-blog .roomify-add-button + button,
-  .page-blog .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button,
-  .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .modal-footer .btn-group .roomify-add-button + button, .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group .page-taxonomy-area .field-name-field-field-link-to-area-blog a + button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .modal-footer .btn-group a + button, .modal-footer .btn-group .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .modal-footer .btn-group button + button {
+  .modal-footer .btn-group .btn + .btn {
     margin-left: -1px; }
   .modal-footer .btn-block + .btn-block {
     margin-left: 0; }
@@ -7072,11 +5802,7 @@ button.close {
   color: #fff;
   text-align: center;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6); }
-  .carousel-caption .btn, .carousel-caption .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .carousel-caption .checkout-continue, .carousel-caption .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .carousel-caption .checkout-back,
-  .carousel-caption .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .carousel-caption .checkout-cancel, .carousel-caption .page-blog .pager-load-more a, .page-blog .pager-load-more .carousel-caption a,
-  .carousel-caption .page-blog .roomify-add-button,
-  .page-blog .carousel-caption .roomify-add-button, .carousel-caption .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .carousel-caption a, .carousel-caption .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .carousel-caption button {
+  .carousel-caption .btn {
     text-shadow: none; }
 
 @media screen and (min-width: 768px) {
@@ -7102,10 +5828,10 @@ button.close {
 
   .carousel-indicators {
     bottom: 20px; } }
-.clearfix:before, .roomify-footer .footer-social-icons:before, .clearfix:after, .roomify-footer .footer-social-icons:after {
+.clearfix:before, .clearfix:after {
   content: " ";
   display: table; }
-.clearfix:after, .roomify-footer .footer-social-icons:after {
+.clearfix:after {
   clear: both; }
 
 .center-block {
@@ -7322,121 +6048,43 @@ button.close {
 .navbar {
   border-width: 0 1px 4px 1px; }
 
-.btn, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel, .page-blog .pager-load-more a,
-.page-blog .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button {
+.btn {
   padding: 9px 12px 7px;
   border-width: 0 1px 4px 1px;
   font-size: 12px;
   font-weight: bold;
   text-transform: uppercase; }
-  .btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover, .page-blog .pager-load-more a:hover,
-  .page-blog .roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover {
+  .btn:hover {
     margin-top: 1px;
     border-bottom-width: 3px; }
-  .btn:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:active,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:active, .page-blog .pager-load-more a:active,
-  .page-blog .roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:active {
+  .btn:active {
     margin-top: 2px;
     border-bottom-width: 2px;
     -webkit-box-shadow: none;
     box-shadow: none; }
-  .btn-lg, .btn-group-lg > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-cancel, .page-blog .pager-load-more .btn-group-lg > a,
-  .page-blog .btn-group-lg > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-lg > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-lg > button, .btn-group-lg > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-lg > .checkout-cancel, .page-blog .pager-load-more .btn-group-lg > a,
-  .page-blog .btn-group-lg > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-lg > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-lg > button {
+  .btn-lg, .btn-group-lg > .btn, .btn-group-lg > .btn {
     padding: 15px 16px 13px;
     line-height: 15px; }
-  .btn-sm, .btn-group-sm > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-cancel, .page-blog .pager-load-more .btn-group-sm > a,
-  .page-blog .btn-group-sm > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-sm > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-sm > button, .btn-group-sm > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .checkout-cancel, .page-blog .pager-load-more .btn-group-sm > a,
-  .page-blog .btn-group-sm > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-sm > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-sm > button {
+  .btn-sm, .btn-group-sm > .btn, .btn-group-sm > .btn {
     padding: 6px 10px 4px; }
-  .btn-xs, .btn-group-xs > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-cancel, .page-blog .pager-load-more .btn-group-xs > a,
-  .page-blog .btn-group-xs > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button, .btn-group-xs > .btn, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-back,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .checkout-cancel, .page-blog .pager-load-more .btn-group-xs > a,
-  .page-blog .btn-group-xs > .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button {
+  .btn-xs, .btn-group-xs > .btn, .btn-group-xs > .btn {
     padding: 3px 5px 1px; }
-  .btn-default:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover, .page-blog .pager-load-more a:hover,
-  .page-blog .roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover, .btn-default:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus, .page-blog .pager-load-more a:focus,
-  .page-blog .roomify-add-button:focus, .page-taxonomy-area .field-name-field-field-link-to-area-blog a:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, .btn-group.open .dropdown-toggle.btn-default, .btn-group.open .page-checkout fieldset.panel-default.checkout-buttons .dropdown-toggle.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group.open .dropdown-toggle.checkout-continue, .btn-group.open .page-checkout fieldset.panel-default.checkout-buttons .dropdown-toggle.checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group.open .dropdown-toggle.checkout-back,
-  .btn-group.open .page-checkout fieldset.panel-default.checkout-buttons .dropdown-toggle.checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group.open .dropdown-toggle.checkout-cancel, .btn-group.open .page-blog .pager-load-more a.dropdown-toggle, .page-blog .pager-load-more .btn-group.open a.dropdown-toggle,
-  .btn-group.open .page-blog .dropdown-toggle.roomify-add-button,
-  .page-blog .btn-group.open .dropdown-toggle.roomify-add-button, .btn-group.open .page-taxonomy-area .field-name-field-field-link-to-area-blog a.dropdown-toggle, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group.open a.dropdown-toggle, .btn-group.open .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.dropdown-toggle, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group.open button.dropdown-toggle {
+  .btn-default:hover, .btn-default:focus, .btn-group.open .dropdown-toggle.btn-default {
     background-color: #eeeeee;
     border-color: #e2e2e2; }
   .btn-primary:hover, .btn-primary:focus, .btn-group.open .dropdown-toggle.btn-primary {
     background-color: #158CBA;
     border-color: #127ba3; }
-  .btn-success:hover, body .sidebar-nav .pane-user-login .form-actions button:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:hover, .btn-success:focus, body .sidebar-nav .pane-user-login .form-actions button:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue:focus, .btn-group.open .dropdown-toggle.btn-success, .btn-group.open body .sidebar-nav .pane-user-login .form-actions button.dropdown-toggle, body .sidebar-nav .pane-user-login .form-actions .btn-group.open button.dropdown-toggle, .btn-group.open .page-checkout fieldset.panel-default.checkout-buttons .dropdown-toggle.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .btn-group.open .dropdown-toggle.checkout-continue {
+  .btn-success:hover, .btn-success:focus, .btn-group.open .dropdown-toggle.btn-success {
     background-color: #28B62C;
     border-color: #23a127; }
   .btn-info:hover, .btn-info:focus, .btn-group.open .dropdown-toggle.btn-info {
     background-color: #75CAEB;
     border-color: #5fc1e8; }
-  .btn-warning:hover, .page-checkout #edit-customer-profile-billing-edit-button:hover, .btn-warning:focus, .page-checkout #edit-customer-profile-billing-edit-button:focus, .btn-group.open .dropdown-toggle.btn-warning, .btn-group.open .page-checkout .dropdown-toggle#edit-customer-profile-billing-edit-button, .page-checkout .btn-group.open .dropdown-toggle#edit-customer-profile-billing-edit-button {
+  .btn-warning:hover, .btn-warning:focus, .btn-group.open .dropdown-toggle.btn-warning {
     background-color: #FF851B;
     border-color: #ff7702; }
-  .btn-danger:hover, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:hover,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:hover,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:hover,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:hover,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:hover, .btn-danger:focus, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back:focus,
-  .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:focus,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:focus,
-  #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:focus,
-  #property-bat-facets-availability .form-wrapper .search-submit .form-submit:focus, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:focus,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:focus,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:focus, .btn-group.open .dropdown-toggle.btn-danger, .btn-group.open .page-checkout fieldset.panel-default.checkout-buttons .dropdown-toggle.checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .btn-group.open .dropdown-toggle.checkout-back,
-  .btn-group.open .page-checkout fieldset.panel-default.checkout-buttons .dropdown-toggle.checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .btn-group.open .dropdown-toggle.checkout-cancel, .btn-group.open #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .dropdown-toggle.form-submit, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open #property-bat-activity-facets-availability .form-wrapper .search-submit .dropdown-toggle.form-submit,
-  #property-bat-activity-facets-availability .form-wrapper .search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open #roomify-property-search-block-form .form-wrapper .search-availability-submit .dropdown-toggle.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-availability-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open #roomify-property-search-block-form .form-wrapper .search-submit .dropdown-toggle.form-submit,
-  #roomify-property-search-block-form .form-wrapper .search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open #property-bat-facets-availability .form-wrapper .search-availability-submit .dropdown-toggle.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-availability-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open #property-bat-facets-availability .form-wrapper .search-submit .dropdown-toggle.form-submit,
-  #property-bat-facets-availability .form-wrapper .search-submit .btn-group.open .dropdown-toggle.form-submit, .btn-group.open .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button.dropdown-toggle, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group.open button.dropdown-toggle, .btn-group.open body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .dropdown-toggle.form-submit, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .btn-group.open .dropdown-toggle.form-submit,
-  .btn-group.open body.page-single-property-listing .pane-locanda-availability-search form .search-submit .dropdown-toggle.form-submit,
-  body.page-single-property-listing .pane-locanda-availability-search form .search-submit .btn-group.open .dropdown-toggle.form-submit {
+  .btn-danger:hover, .btn-danger:focus, .btn-group.open .dropdown-toggle.btn-danger {
     background-color: #FF4136;
     border-color: #ff291d; }
   .btn-group.open .dropdown-toggle {
@@ -7447,204 +6095,18 @@ button.close {
   margin-top: 8px; }
 .navbar-btn:active {
   margin-top: 9px; }
-.navbar-btn.btn-sm:hover, .btn-group-sm > .navbar-btn.btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-back:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-cancel:hover, .page-blog .pager-load-more .btn-group-sm > a.navbar-btn:hover,
-.page-blog .btn-group-sm > .navbar-btn.roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-sm > a.navbar-btn:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-sm > button.navbar-btn:hover {
+.navbar-btn.btn-sm:hover, .btn-group-sm > .navbar-btn.btn:hover {
   margin-top: 11px; }
-.navbar-btn.btn-sm:active, .btn-group-sm > .navbar-btn.btn:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-back:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-sm > .navbar-btn.checkout-cancel:active, .page-blog .pager-load-more .btn-group-sm > a.navbar-btn:active,
-.page-blog .btn-group-sm > .navbar-btn.roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-sm > a.navbar-btn:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-sm > button.navbar-btn:active {
+.navbar-btn.btn-sm:active, .btn-group-sm > .navbar-btn.btn:active {
   margin-top: 12px; }
-.navbar-btn.btn-xs:hover, .btn-group-xs > .navbar-btn.btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-back:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-cancel:hover, .page-blog .pager-load-more .btn-group-xs > a.navbar-btn:hover,
-.page-blog .btn-group-xs > .navbar-btn.roomify-add-button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a.navbar-btn:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button.navbar-btn:hover {
+.navbar-btn.btn-xs:hover, .btn-group-xs > .navbar-btn.btn:hover {
   margin-top: 15px; }
-.navbar-btn.btn-xs:active, .btn-group-xs > .navbar-btn.btn:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-back:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-xs > .navbar-btn.checkout-cancel:active, .page-blog .pager-load-more .btn-group-xs > a.navbar-btn:active,
-.page-blog .btn-group-xs > .navbar-btn.roomify-add-button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-xs > a.navbar-btn:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-xs > button.navbar-btn:active {
+.navbar-btn.btn-xs:active, .btn-group-xs > .navbar-btn.btn:active {
   margin-top: 16px; }
 
-.btn-group-vertical .btn + .btn:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .btn:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .btn:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .btn:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .btn:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .btn:hover, .btn-group-vertical .page-blog .pager-load-more a + .btn:hover, .page-blog .pager-load-more .btn-group-vertical a + .btn:hover,
-.btn-group-vertical .page-blog .roomify-add-button + .btn:hover,
-.page-blog .btn-group-vertical .roomify-add-button + .btn:hover, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .btn:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .btn:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .btn:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .btn:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .btn + .checkout-continue:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .checkout-continue:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .checkout-continue:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-continue:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .checkout-continue:hover, .btn-group-vertical .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more a + .checkout-continue:hover, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical a + .checkout-continue:hover,
-.btn-group-vertical .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .roomify-add-button + .checkout-continue:hover,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical .roomify-add-button + .checkout-continue:hover, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-continue:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .checkout-continue:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-continue:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue:hover, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .checkout-continue:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .btn + .checkout-back:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .checkout-back:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .checkout-back:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-back:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .checkout-back:hover, .btn-group-vertical .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more a + .checkout-back:hover, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical a + .checkout-back:hover,
-.btn-group-vertical .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .roomify-add-button + .checkout-back:hover,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical .roomify-add-button + .checkout-back:hover, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-back:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .checkout-back:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-back:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back:hover, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .checkout-back:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .btn + .checkout-cancel:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .checkout-cancel:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .checkout-cancel:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .checkout-cancel:hover,
-.btn-group-vertical .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more a + .checkout-cancel:hover,
-.page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical a + .checkout-cancel:hover,
-.btn-group-vertical .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .roomify-add-button + .checkout-cancel:hover,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical .roomify-add-button + .checkout-cancel:hover,
-.btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-cancel:hover,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .checkout-cancel:hover,
-.btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-cancel:hover,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .checkout-cancel:hover, .btn-group-vertical .page-blog .pager-load-more .btn + a:hover, .page-blog .pager-load-more .btn-group-vertical .btn + a:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-continue + a:hover, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more .checkout-continue + a:hover, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + a:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-back + a:hover, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more .checkout-back + a:hover, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + a:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-cancel + a:hover,
-.page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more .checkout-cancel + a:hover,
-.page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + a:hover, .btn-group-vertical .page-blog .pager-load-more a + a:hover, .page-blog .pager-load-more .btn-group-vertical a + a:hover,
-.btn-group-vertical .page-blog .pager-load-more .roomify-add-button + a:hover,
-.page-blog .btn-group-vertical .pager-load-more .roomify-add-button + a:hover,
-.page-blog .pager-load-more .btn-group-vertical .roomify-add-button + a:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more button + a:hover, .page-blog .pager-load-more .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog .pager-load-more button + a:hover, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + a:hover,
-.btn-group-vertical .page-blog .btn + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .btn + .roomify-add-button:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-continue + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .roomify-add-button:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .checkout-continue + .roomify-add-button:hover,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .roomify-add-button:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-back + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .roomify-add-button:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .checkout-back + .roomify-add-button:hover,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .roomify-add-button:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-cancel + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .roomify-add-button:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .checkout-cancel + .roomify-add-button:hover,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .roomify-add-button:hover,
-.btn-group-vertical .page-blog .pager-load-more a + .roomify-add-button:hover,
-.page-blog .pager-load-more .btn-group-vertical a + .roomify-add-button:hover,
-.btn-group-vertical .page-blog .roomify-add-button + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .roomify-add-button + .roomify-add-button:hover,
-.btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog a + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .roomify-add-button:hover,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-blog a + .roomify-add-button:hover,
-.page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .roomify-add-button:hover,
-.btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog button + .roomify-add-button:hover,
-.page-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .roomify-add-button:hover,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog button + .roomify-add-button:hover,
-.page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .roomify-add-button:hover, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .btn + a:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + a:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + a:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a:hover,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a:hover,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + a:hover,
-.btn-group-vertical .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a:hover,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-blog .roomify-add-button + a:hover,
-.page-blog .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a:hover,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .btn-group-vertical .roomify-add-button + a:hover, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + a:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + a:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .btn + button:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + button:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + button:hover, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + button:hover, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + button:hover,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button:hover,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + button:hover,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button:hover,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + button:hover, .btn-group-vertical .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog .pager-load-more a + button:hover, .page-blog .pager-load-more .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .btn-group-vertical a + button:hover,
-.btn-group-vertical .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button:hover,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog .roomify-add-button + button:hover,
-.page-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button:hover,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .btn-group-vertical .roomify-add-button + button:hover, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + button:hover, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + button:hover, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + button:hover, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + button:hover {
+.btn-group-vertical .btn + .btn:hover {
   border-top-width: 1px; }
-.btn-group-vertical .btn + .btn:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .btn:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .btn:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .btn:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .btn:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .btn:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .btn:active, .btn-group-vertical .page-blog .pager-load-more a + .btn:active, .page-blog .pager-load-more .btn-group-vertical a + .btn:active,
-.btn-group-vertical .page-blog .roomify-add-button + .btn:active,
-.page-blog .btn-group-vertical .roomify-add-button + .btn:active, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .btn:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .btn:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .btn:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .btn:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .btn + .checkout-continue:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .checkout-continue:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .checkout-continue:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-continue:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .checkout-continue:active, .btn-group-vertical .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more a + .checkout-continue:active, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical a + .checkout-continue:active,
-.btn-group-vertical .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .roomify-add-button + .checkout-continue:active,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-continue:active,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical .roomify-add-button + .checkout-continue:active, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-continue:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .checkout-continue:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-continue:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-continue:active, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .checkout-continue:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .btn + .checkout-back:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .checkout-back:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .checkout-back:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-back:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .checkout-back:active, .btn-group-vertical .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more a + .checkout-back:active, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical a + .checkout-back:active,
-.btn-group-vertical .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .roomify-add-button + .checkout-back:active,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-back:active,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical .roomify-add-button + .checkout-back:active, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-back:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .checkout-back:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-back:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-back:active, .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .checkout-back:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .btn + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .btn + .checkout-cancel:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .checkout-cancel:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .checkout-cancel:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .checkout-cancel:active,
-.btn-group-vertical .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more a + .checkout-cancel:active,
-.page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .btn-group-vertical a + .checkout-cancel:active,
-.btn-group-vertical .page-blog .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .roomify-add-button + .checkout-cancel:active,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .roomify-add-button + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .page-blog .btn-group-vertical .roomify-add-button + .checkout-cancel:active,
-.btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .checkout-cancel:active,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons a + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .checkout-cancel:active,
-.btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .checkout-cancel:active,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons button + .checkout-cancel:active,
-.page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .checkout-cancel:active, .btn-group-vertical .page-blog .pager-load-more .btn + a:active, .page-blog .pager-load-more .btn-group-vertical .btn + a:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-continue + a:active, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more .checkout-continue + a:active, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + a:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-back + a:active, .page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more .checkout-back + a:active, .page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + a:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .pager-load-more .checkout-cancel + a:active,
-.page-blog .pager-load-more .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .pager-load-more .checkout-cancel + a:active,
-.page-blog .pager-load-more .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + a:active, .btn-group-vertical .page-blog .pager-load-more a + a:active, .page-blog .pager-load-more .btn-group-vertical a + a:active,
-.btn-group-vertical .page-blog .pager-load-more .roomify-add-button + a:active,
-.page-blog .btn-group-vertical .pager-load-more .roomify-add-button + a:active,
-.page-blog .pager-load-more .btn-group-vertical .roomify-add-button + a:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more button + a:active, .page-blog .pager-load-more .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog .pager-load-more button + a:active, .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + a:active,
-.btn-group-vertical .page-blog .btn + .roomify-add-button:active,
-.page-blog .btn-group-vertical .btn + .roomify-add-button:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-continue + .roomify-add-button:active,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + .roomify-add-button:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .checkout-continue + .roomify-add-button:active,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + .roomify-add-button:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-back + .roomify-add-button:active,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + .roomify-add-button:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .checkout-back + .roomify-add-button:active,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + .roomify-add-button:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-blog .checkout-cancel + .roomify-add-button:active,
-.page-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + .roomify-add-button:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-blog .checkout-cancel + .roomify-add-button:active,
-.page-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + .roomify-add-button:active,
-.btn-group-vertical .page-blog .pager-load-more a + .roomify-add-button:active,
-.page-blog .pager-load-more .btn-group-vertical a + .roomify-add-button:active,
-.btn-group-vertical .page-blog .roomify-add-button + .roomify-add-button:active,
-.page-blog .btn-group-vertical .roomify-add-button + .roomify-add-button:active,
-.btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog a + .roomify-add-button:active,
-.page-blog .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + .roomify-add-button:active,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-blog a + .roomify-add-button:active,
-.page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + .roomify-add-button:active,
-.btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog button + .roomify-add-button:active,
-.page-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + .roomify-add-button:active,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog button + .roomify-add-button:active,
-.page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + .roomify-add-button:active, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .btn + a:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + a:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-continue + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + a:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + a:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-back + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + a:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a:active,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + a:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .checkout-cancel + a:active,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + a:active,
-.btn-group-vertical .page-blog .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a:active,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-blog .roomify-add-button + a:active,
-.page-blog .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .roomify-add-button + a:active,
-.page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .btn-group-vertical .roomify-add-button + a:active, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + a:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + a:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog button + a:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + a:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .btn + button:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue + button:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-continue + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-continue + button:active, .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-back + button:active, .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-back + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-back + button:active,
-.btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button:active,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel + button:active,
-.page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .checkout-cancel + button:active,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-checkout fieldset.panel-default.checkout-buttons .btn-group-vertical .checkout-cancel + button:active, .btn-group-vertical .page-blog .pager-load-more .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog .pager-load-more a + button:active, .page-blog .pager-load-more .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .pager-load-more .btn-group-vertical a + button:active,
-.btn-group-vertical .page-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button:active,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-blog .roomify-add-button + button:active,
-.page-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .roomify-add-button + button:active,
-.page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .btn-group-vertical .roomify-add-button + button:active, .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical .page-taxonomy-area .field-name-field-field-link-to-area-blog a + button:active, .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit a + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-taxonomy-area .field-name-field-field-link-to-area-blog .btn-group-vertical a + button:active, .btn-group-vertical .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button + button:active, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .btn-group-vertical button + button:active {
+.btn-group-vertical .btn + .btn:active {
   border-top-width: 2px; }
 
 .text-primary,
@@ -7929,14 +6391,11 @@ a.list-group-item-danger.active:hover, a.list-group-item-danger.active:focus {
     width: 100%; } }
 
 /* set a max-width for horizontal fluid layout and make it centered */
-.btn, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel, .page-blog .pager-load-more a,
-.page-blog .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button {
+.btn {
   font-weight: 400; }
 
 @media (min-width: 1200px) {
-  .container, .messages-container, .page-taxonomy-area .panel_sl_content, body.page-single-property-listing .panel-content-wrapper,
-  body.page-single-property-listing .panel-content-bottom {
+  .container {
     width: 1200px; } }
 
 /* Text meant only for screen readers */
@@ -7978,7 +6437,7 @@ strong {
 
 h1, h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .field-name-field-area-title-description,
 .page-taxonomy-area .field-name-field-area-title-blog-posts,
-.page-taxonomy-area .field-name-field-title-featured-properties, h3, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
+.page-taxonomy-area .field-name-field-title-featured-properties, h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-name, .page-activities-search .view-display-id-panel_pane_3 .property-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_3 .property-row .views-field-name, .page-blog .panel_sl_right .panel-pane .pane-title, .node-type-blog .panel_sl_right .panel-pane .pane-title, .page-things-to-do .panel_sl_right .panel-pane .pane-title, .node-type-activity .panel_sl_right .panel-pane .pane-title, .page-taxonomy-area .field-name-field-area-description-subtitle,
 .page-taxonomy-area .field-name-field-area-description-blog-post,
@@ -8002,7 +6461,7 @@ h2, .page-taxonomy-area .pane-term-name .pane-content, .page-taxonomy-area .fiel
   margin-bottom: 20px;
   line-height: 0.93; }
 
-h3, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
+h3, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu .sidebar-profile-message, .page-listing .pane-roomify-property-name, .page-checkout-review .checkout_review .pane-title td, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-name, .page-activities-search .view-display-id-panel_pane_3 .property-row .views-field-name,
 .page-availability-search .view-display-id-panel_pane_3 .property-row .views-field-name, .page-blog .panel_sl_right .panel-pane .pane-title, .node-type-blog .panel_sl_right .panel-pane .pane-title, .page-things-to-do .panel_sl_right .panel-pane .pane-title, .node-type-activity .panel_sl_right .panel-pane .pane-title, .page-taxonomy-area .field-name-field-area-description-subtitle,
 .page-taxonomy-area .field-name-field-area-description-blog-post,
@@ -8080,22 +6539,39 @@ blockquote {
       background: white;
       border: 1px solid white; }
 
-.btn, .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-.page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel, .page-blog .pager-load-more a,
-.page-blog .roomify-add-button, .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button {
+.btn {
   padding: 6px 10px 4px; }
 
-.messages-container .messages-row {
-  margin-left: -15px;
-  margin-right: -15px; }
-  .messages-container .messages-row:before, .messages-container .messages-row:after {
+.messages-container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 15px;
+  padding-right: 15px; }
+  .messages-container:before, .messages-container:after {
     content: " ";
     display: table; }
-  .messages-container .messages-row:after {
+  .messages-container:after {
     clear: both; }
-  .messages-container .messages-row .alert {
-    border-radius: 0;
-    margin-bottom: 0; }
+  @media (min-width: 768px) {
+    .messages-container {
+      width: 750px; } }
+  @media (min-width: 992px) {
+    .messages-container {
+      width: 970px; } }
+  @media (min-width: 1200px) {
+    .messages-container {
+      width: 1170px; } }
+  .messages-container .messages-row {
+    margin-left: -15px;
+    margin-right: -15px; }
+    .messages-container .messages-row:before, .messages-container .messages-row:after {
+      content: " ";
+      display: table; }
+    .messages-container .messages-row:after {
+      clear: both; }
+    .messages-container .messages-row .alert {
+      border-radius: 0;
+      margin-bottom: 0; }
 
 #better-messages-wrapper #better-messages-default #messages-inner .content .messages.status,
 #better-messages-wrapper #better-messages-default #messages-inner .content .messages.error,
@@ -8469,9 +6945,7 @@ header.roomify-header {
   border-left: 0;
   border-right: 0; }
   @media (min-width: 768px) {
-    header.roomify-header .container:first-child, header.roomify-header .messages-container:first-child, header.roomify-header .page-taxonomy-area .panel_sl_content:first-child, .page-taxonomy-area header.roomify-header .panel_sl_content:first-child, header.roomify-header body.page-single-property-listing .panel-content-wrapper:first-child, body.page-single-property-listing header.roomify-header .panel-content-wrapper:first-child,
-    header.roomify-header body.page-single-property-listing .panel-content-bottom:first-child,
-    body.page-single-property-listing header.roomify-header .panel-content-bottom:first-child {
+    header.roomify-header .container:first-child {
       padding-left: 0;
       padding-right: 0; } }
   header.roomify-header .navbar-header {
@@ -8605,6 +7079,11 @@ header.roomify-header {
   .roomify-footer .footer-social-icons {
     margin: 0 auto 20px auto;
     max-width: 260px; }
+    .roomify-footer .footer-social-icons:before, .roomify-footer .footer-social-icons:after {
+      content: " ";
+      display: table; }
+    .roomify-footer .footer-social-icons:after {
+      clear: both; }
     .roomify-footer .footer-social-icons .rrssb-buttons li {
       float: none;
       display: inline-block;
@@ -8751,9 +7230,7 @@ body {
       width: 90%;
       display: block;
       margin-left: 5%; }
-      body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .glyphicon, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li a::before, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li button::before,
-      body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-      .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li button::before {
+      body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .glyphicon {
         float: left;
         display: inline-block;
         top: 14px;
@@ -8762,9 +7239,7 @@ body {
         z-index: 99;
         padding-left: 5px;
         color: #03A9F4; }
-        body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .glyphicon:hover, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .pane-roomify-property-flag-favorites-link .flag-favorites a:hover::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li a:hover::before, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button:hover::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li button:hover::before,
-        body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button:hover::before,
-        .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li button:hover::before {
+        body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li .glyphicon:hover {
           color: black; }
       body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li a {
         font-size: 16px;
@@ -8773,9 +7248,7 @@ body {
           color: black; }
       body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover {
         background: #eeeeee; }
-        body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover .glyphicon, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover a::before, body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover button::before,
-        body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-        .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover button::before {
+        body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover .glyphicon {
           color: black; }
         body .sidebar-nav .pane-roomify-sidebar-user-menu .roomify-sidebar-user-menu li:hover a {
           color: black; }
@@ -8811,6 +7284,8 @@ body {
             display: inline-block;
             padding: 0; }
       body .sidebar-nav .pane-user-login .form-actions button {
+        background-color: #28B62C;
+        border-color: #23a127;
         width: 100%;
         font-size: 16px; }
         body .sidebar-nav .pane-user-login .form-actions button span {
@@ -8823,9 +7298,8 @@ body {
         padding: 0; }
       body .sidebar-nav .pane-commerce-cart-cart .line-item-quantity {
         display: none; }
-      body .sidebar-nav .pane-commerce-cart-cart .glyphicon, body .sidebar-nav .pane-commerce-cart-cart .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-commerce-cart-cart a::before, body .sidebar-nav .pane-commerce-cart-cart .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before,
-      body .sidebar-nav .pane-commerce-cart-cart .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-      .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before {
+
+      body .sidebar-nav .pane-commerce-cart-cart .glyphicon {
         font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
@@ -8861,9 +7335,7 @@ body {
       border-bottom: 0;
       font-size: 22px;
       width: 100%; }
-      body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .glyphicon, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a::before, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before,
-      body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-      .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before {
+      body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .glyphicon {
         display: inline-block;
         font-size: 18px;
         margin-right: 6px;
@@ -8915,9 +7387,7 @@ body {
         text-align: left;
         border-bottom: 0;
         width: 100%; }
-        body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .glyphicon, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title a::before, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before,
-        body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-        .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before {
+        body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .glyphicon {
           display: inline-block;
           font-size: 18px;
           margin-right: 6px;
@@ -9031,7 +7501,7 @@ body.toggled #close-sidebar-wrapper {
   width: 100%;
   position: fixed;
   /* Stay in place */
-  z-index: 100;
+  z-index: 1001;
   /* Sit on top */
   left: 0;
   top: 0;
@@ -9254,6 +7724,13 @@ body.toggled #close-sidebar-wrapper {
       -ms-transition: 0.2s background-color ease-in-out;
       -o-transition: 0.2s background-color ease-in-out; }
       .pane-roomify-property-flag-favorites-link .flag-favorites a::before {
+        position: relative;
+        font-family: 'Glyphicons Halflings';
+        font-style: normal;
+        font-weight: normal;
+        line-height: 1;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
         top: auto;
         content: "\e005";
         color: white;
@@ -9415,7 +7892,7 @@ body.toggled #close-sidebar-wrapper {
   .page-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form {
     padding-top: 60px;
     position: relative;
-    border-top: 4px solid #158cba;
+    border-top: 3px solid #158cba;
     width: 100%; }
   .page-listing .pane-locanda-availability-search label,
   .page-listing .pane-roomify-listing-availability-search-block-roomify-listing-search label {
@@ -9423,7 +7900,7 @@ body.toggled #close-sidebar-wrapper {
   .page-listing .pane-locanda-availability-search .listing-base-price,
   .page-listing .pane-roomify-listing-availability-search-block-roomify-listing-search .listing-base-price {
     position: absolute;
-    top: 0;
+    top: -1px;
     right: 0;
     padding: 0 10px;
     background: #127ba3;
@@ -10175,6 +8652,15 @@ body.toggled #close-sidebar-wrapper {
       background-color: #FFFFFF; }
     .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
     .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before {
+      position: relative;
+      top: 1px;
+      display: inline-block;
+      font-family: 'Glyphicons Halflings';
+      font-style: normal;
+      font-weight: normal;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
       content: "\e003";
       margin-right: 10px; }
 .page-conversation-booking .featured-image,
@@ -11095,16 +9581,8 @@ ol.inline.commerce-checkout-progress {
     font-weight: 400;
     display: inline-block;
     width: 45%; }
-    .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .glyphicon, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area a::before, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area button::before,
-    .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area button::before,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .glyphicon,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .pane-roomify-property-flag-favorites-link .flag-favorites a::before,
-    .pane-roomify-property-flag-favorites-link .flag-favorites .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area a::before,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area button::before,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area button::before {
+    .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .glyphicon,
+    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-area .glyphicon {
       margin-right: 6px;
       color: #006699; }
     @media (max-width: 768px) {
@@ -11119,16 +9597,8 @@ ol.inline.commerce-checkout-progress {
     display: inline-block;
     width: 45%;
     font-style: italic; }
-    .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .glyphicon, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description a::before, .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description button::before,
-    .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description button::before,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .glyphicon,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .pane-roomify-property-flag-favorites-link .flag-favorites a::before,
-    .pane-roomify-property-flag-favorites-link .flag-favorites .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description a::before,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description button::before,
-    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description button::before {
+    .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .glyphicon,
+    .page-availability-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description .glyphicon {
       display: none; }
     @media (max-width: 768px) {
       .page-activities-search .view-display-id-panel_pane_1 .views-row .views-field-field-sp-short-description,
@@ -11776,7 +10246,174 @@ ol.inline.commerce-checkout-progress {
       text-transform: capitalize;
       padding: 6px;
       font-size: 15px;
-      width: 100%; }
+      width: 100%;
+      color: #fff;
+      background-color: #FF4136;
+      border-color: #ff291d; }
+      #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.focus,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:focus,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.focus,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:focus,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.focus,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:focus,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.focus,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:focus,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.focus,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit:focus,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.focus {
+        color: #fff;
+        background-color: #ff1103;
+        border-color: #9c0900; }
+      #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:hover,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:hover,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:hover,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:hover,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit:hover {
+        color: #fff;
+        background-color: #ff1103;
+        border-color: #de0c00; }
+      #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.active, .open > #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.active, .open >
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.active, .open >
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.dropdown-toggle,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.active, .open >
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.dropdown-toggle,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.active, .open >
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.active, .open >
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle {
+        color: #fff;
+        background-color: #ff1103;
+        border-color: #de0c00; }
+        #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active.focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.active:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.active:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.active.focus, .open > #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle:hover, .open > #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle:focus, .open > #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle.focus,
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active:hover,
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active:focus,
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active.focus,
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.active:hover,
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.active:focus,
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.active.focus, .open >
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle:hover, .open >
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle:focus, .open >
+        #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle.focus,
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active:hover,
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active:focus,
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active.focus,
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.active:hover,
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.active:focus,
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.active.focus, .open >
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.dropdown-toggle:hover, .open >
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.dropdown-toggle:focus, .open >
+        #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.dropdown-toggle.focus,
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active:hover,
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active:focus,
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active.focus,
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.active:hover,
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.active:focus,
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.active.focus, .open >
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.dropdown-toggle:hover, .open >
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.dropdown-toggle:focus, .open >
+        #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.dropdown-toggle.focus,
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active:hover,
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active:focus,
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active.focus,
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.active:hover,
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.active:focus,
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.active.focus, .open >
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle:hover, .open >
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle:focus, .open >
+        #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle.focus,
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active:hover,
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active:focus,
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active.focus,
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit.active:hover,
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit.active:focus,
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit.active.focus, .open >
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle:hover, .open >
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle:focus, .open >
+        #property-bat-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle.focus {
+          color: #fff;
+          background-color: #de0c00;
+          border-color: #9c0900; }
+      #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:active, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.active, .open > #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:active,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.active, .open >
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:active,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.active, .open >
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.dropdown-toggle,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:active,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.active, .open >
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.dropdown-toggle,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:active,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.active, .open >
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.dropdown-toggle,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit:active,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.active, .open >
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.dropdown-toggle {
+        background-image: none; }
+      #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.disabled:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.disabled:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.disabled.focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit[disabled]:hover, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit[disabled]:focus, #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit[disabled].focus, fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:hover, fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit:focus, fieldset[disabled] #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit.focus,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.disabled:hover,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.disabled:focus,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.disabled.focus,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit[disabled]:hover,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit[disabled]:focus,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit[disabled].focus, fieldset[disabled]
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:hover, fieldset[disabled]
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit:focus, fieldset[disabled]
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit.focus,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.disabled:hover,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.disabled:focus,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.disabled.focus,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit[disabled]:hover,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit[disabled]:focus,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit[disabled].focus, fieldset[disabled]
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:hover, fieldset[disabled]
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit:focus, fieldset[disabled]
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit.focus,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.disabled:hover,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.disabled:focus,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.disabled.focus,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit[disabled]:hover,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit[disabled]:focus,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit[disabled].focus, fieldset[disabled]
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:hover, fieldset[disabled]
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit:focus, fieldset[disabled]
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit.focus,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.disabled:hover,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.disabled:focus,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.disabled.focus,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit[disabled]:hover,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit[disabled]:focus,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit[disabled].focus, fieldset[disabled]
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:hover, fieldset[disabled]
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit:focus, fieldset[disabled]
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit.focus,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.disabled:hover,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.disabled:focus,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.disabled.focus,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit[disabled]:hover,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit[disabled]:focus,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit[disabled].focus, fieldset[disabled]
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit:hover, fieldset[disabled]
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit:focus, fieldset[disabled]
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit.focus {
+        background-color: #FF4136;
+        border-color: #ff291d; }
+      #property-bat-activity-facets-availability .form-wrapper .search-availability-submit .form-submit .badge,
+      #property-bat-activity-facets-availability .form-wrapper .search-submit .form-submit .badge,
+      #roomify-property-search-block-form .form-wrapper .search-availability-submit .form-submit .badge,
+      #roomify-property-search-block-form .form-wrapper .search-submit .form-submit .badge,
+      #property-bat-facets-availability .form-wrapper .search-availability-submit .form-submit .badge,
+      #property-bat-facets-availability .form-wrapper .search-submit .form-submit .badge {
+        color: #FF4136;
+        background-color: #fff; }
   #property-bat-activity-facets-availability .form-wrapper input, #property-bat-activity-facets-availability .form-wrapper select, #property-bat-activity-facets-availability .form-wrapper .form-control,
   #roomify-property-search-block-form .form-wrapper input,
   #roomify-property-search-block-form .form-wrapper select,
@@ -11832,16 +10469,8 @@ ol.inline.commerce-checkout-progress {
     color: #666;
     border-bottom: 1px solid #d0d0d0;
     border-top: 1px solid #d0d0d0; }
-    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title .glyphicon, .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title a::before, .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title button::before,
-    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title button::before,
-    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title .glyphicon,
-    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before,
-    .pane-roomify-property-flag-favorites-link .flag-favorites .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title a::before,
-    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title button::before,
-    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title button::before {
+    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-title .glyphicon,
+    .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-title .glyphicon {
       display: none; }
   .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .pane-current-search-properties .pane-content,
   .page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block .pane-content {
@@ -12571,9 +11200,7 @@ ol.inline.commerce-checkout-progress {
         float: left; }
       .page-blog .panel_sl_right .panel-pane .pane-content .views-row a:hover {
         text-decoration: underline; }
-    .page-blog .panel_sl_right .panel-pane .pane-title .glyphicon, .page-blog .panel_sl_right .panel-pane .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-blog .panel_sl_right .panel-pane .pane-title a::before, .page-blog .panel_sl_right .panel-pane .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-blog .panel_sl_right .panel-pane .pane-title button::before,
-    .page-blog .panel_sl_right .panel-pane .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-blog .panel_sl_right .panel-pane .pane-title button::before {
+    .page-blog .panel_sl_right .panel-pane .pane-title .glyphicon {
       display: none; }
   .page-blog .panel_sl_right .facetapi-facetapi-checkbox-links {
     padding-left: 0;
@@ -12608,16 +11235,10 @@ ol.inline.commerce-checkout-progress {
   .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node {
     text-align: right;
     margin-top: 25px; }
-    .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-continue, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-back,
-    .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-cancel, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .pager-load-more a, .page-blog .pager-load-more .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node a,
-    .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .roomify-add-button, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node a, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node button {
+    .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn {
       font-size: 15px;
       width: 140px; }
-      .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn a, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue a, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-continue a, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-back a, .page-checkout fieldset.panel-default.checkout-buttons .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-back a,
-      .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel a,
-      .page-checkout fieldset.panel-default.checkout-buttons .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-cancel a, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .pager-load-more a a, .page-blog .pager-load-more .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node a a,
-      .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .roomify-add-button a, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-taxonomy-area .field-name-field-field-link-to-area-blog a a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node a a, .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node button a {
+      .page-blog .view-id-blog_travel.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn a {
         color: white; }
 .page-blog .view-featured-properties.view-display-id-panel_pane_2 .views-row {
   display: inline-block;
@@ -12760,19 +11381,13 @@ ol.inline.commerce-checkout-progress {
     display: inline-block;
     float: left;
     color: #5D5D5D; }
-    .node-type-blog .roomify-blog-icon .pane-title .glyphicon, .node-type-blog .roomify-blog-icon .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .roomify-blog-icon .pane-title a::before, .node-type-blog .roomify-blog-icon .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon .pane-title button::before,
-    .node-type-blog .roomify-blog-icon .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon .pane-title button::before {
+    .node-type-blog .roomify-blog-icon .pane-title .glyphicon {
       margin-right: 8px;
       font-size: 16px;
       top: 3px; }
   .node-type-blog .roomify-blog-icon .pane-content {
     display: inline-block; }
-  .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories a::before, .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories button::before,
-  .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories button::before, .node-type-blog .roomify-blog-icon.pane-node-field-tags .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-tags .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .roomify-blog-icon.pane-node-field-tags a::before, .node-type-blog .roomify-blog-icon.pane-node-field-tags .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-tags button::before,
-  .node-type-blog .roomify-blog-icon.pane-node-field-tags .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-tags button::before {
+  .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-tags .glyphicon {
     margin-right: 13px; }
   .node-type-blog .roomify-blog-icon.pane-node-field-blog-area {
     display: inline-block;
@@ -12787,9 +11402,7 @@ ol.inline.commerce-checkout-progress {
     @media (max-width: 480px) {
       .node-type-blog .roomify-blog-icon.pane-node-field-blog-area {
         width: 100%; } }
-    .node-type-blog .roomify-blog-icon.pane-node-field-blog-area .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-blog-area .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .roomify-blog-icon.pane-node-field-blog-area a::before, .node-type-blog .roomify-blog-icon.pane-node-field-blog-area .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-blog-area button::before,
-    .node-type-blog .roomify-blog-icon.pane-node-field-blog-area .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-blog-area button::before {
+    .node-type-blog .roomify-blog-icon.pane-node-field-blog-area .glyphicon {
       color: #0C628F;
       margin-right: 10px;
       top: 5px; }
@@ -12811,11 +11424,7 @@ ol.inline.commerce-checkout-progress {
         margin-left: 5px; }
     .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .field-item:last-child:after, .node-type-blog .roomify-blog-icon.pane-node-field-tags .field-item:last-child:after {
       content: ""; }
-    .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories a::before, .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories button::before,
-    .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories button::before, .node-type-blog .roomify-blog-icon.pane-node-field-tags .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-tags .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .roomify-blog-icon.pane-node-field-tags a::before, .node-type-blog .roomify-blog-icon.pane-node-field-tags .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-tags button::before,
-    .node-type-blog .roomify-blog-icon.pane-node-field-tags .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .roomify-blog-icon.pane-node-field-tags button::before {
+    .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories .glyphicon, .node-type-blog .roomify-blog-icon.pane-node-field-tags .glyphicon {
       margin-right: 10px;
       top: 7px; }
   .node-type-blog .roomify-blog-icon.pane-node-field-blog-categories {
@@ -12857,9 +11466,7 @@ ol.inline.commerce-checkout-progress {
       float: left; }
     .node-type-blog .panel_sl_right .panel-pane .pane-content .views-row a:hover {
       text-decoration: underline; }
-    .node-type-blog .panel_sl_right .panel-pane .pane-title .glyphicon, .node-type-blog .panel_sl_right .panel-pane .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .panel_sl_right .panel-pane .pane-title a::before, .node-type-blog .panel_sl_right .panel-pane .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .panel_sl_right .panel-pane .pane-title button::before,
-    .node-type-blog .panel_sl_right .panel-pane .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .panel_sl_right .panel-pane .pane-title button::before {
+    .node-type-blog .panel_sl_right .panel-pane .pane-title .glyphicon {
       display: none; }
   .node-type-blog .panel_sl_right .pane-blog-panel-pane-10,
   .node-type-blog .panel_sl_right .pane-blog-panel-pane-4 {
@@ -12947,9 +11554,7 @@ ol.inline.commerce-checkout-progress {
     border-bottom: 1px solid #ececec;
     padding-bottom: 15px;
     margin-bottom: 25px; }
-    .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title .glyphicon, .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title a::before, .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title button::before,
-    .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title button::before {
+    .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-title .glyphicon {
       display: none; }
   .node-type-blog .panel-content-bottom .pane-blog-panel-pane-9 .pane-content {
     margin-bottom: 25px; }
@@ -13051,9 +11656,7 @@ ol.inline.commerce-checkout-progress {
       float: left; }
     .page-things-to-do .panel_sl_right .panel-pane .pane-content .views-row a:hover {
       text-decoration: underline; }
-    .page-things-to-do .panel_sl_right .panel-pane .pane-title .glyphicon, .page-things-to-do .panel_sl_right .panel-pane .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-things-to-do .panel_sl_right .panel-pane .pane-title a::before, .page-things-to-do .panel_sl_right .panel-pane .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-things-to-do .panel_sl_right .panel-pane .pane-title button::before,
-    .page-things-to-do .panel_sl_right .panel-pane .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-things-to-do .panel_sl_right .panel-pane .pane-title button::before {
+    .page-things-to-do .panel_sl_right .panel-pane .pane-title .glyphicon {
       display: none; }
   .page-things-to-do .panel_sl_right .facetapi-facetapi-checkbox-links {
     padding-left: 0;
@@ -13091,18 +11694,10 @@ ol.inline.commerce-checkout-progress {
     text-align: right;
     display: inline-block;
     margin-top: 25px; }
-    .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-continue, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-back,
-    .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-cancel, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-blog .pager-load-more a, .page-blog .pager-load-more .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node a,
-    .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-blog .roomify-add-button,
-    .page-blog .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .roomify-add-button, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node a, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node button {
+    .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn {
       font-size: 15px;
       width: 140px; }
-      .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn a, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue a, .page-checkout fieldset.panel-default.checkout-buttons .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-continue a, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-back a, .page-checkout fieldset.panel-default.checkout-buttons .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-back a,
-      .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel a,
-      .page-checkout fieldset.panel-default.checkout-buttons .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .checkout-cancel a, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-blog .pager-load-more a a, .page-blog .pager-load-more .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node a a,
-      .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-blog .roomify-add-button a,
-      .page-blog .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .roomify-add-button a, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-taxonomy-area .field-name-field-field-link-to-area-blog a a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node a a, .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button a, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node button a {
+      .page-things-to-do .view-id-things_to_do_index.view-display-id-panel_pane_1 .views-row .views-field-view-node .btn a {
         color: white; }
 .page-things-to-do .view-featured-properties.view-display-id-panel_pane_2 .views-row {
   display: inline-block;
@@ -13152,9 +11747,7 @@ ol.inline.commerce-checkout-progress {
     display: inline-block;
     font-weight: 300;
     font-size: 15px; }
-  .node-type-activity .pane-node-field-activity-type .glyphicon, .node-type-activity .pane-node-field-activity-type .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-activity .pane-node-field-activity-type a::before, .node-type-activity .pane-node-field-activity-type .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-activity .pane-node-field-activity-type button::before,
-  .node-type-activity .pane-node-field-activity-type .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-  .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-activity .pane-node-field-activity-type button::before {
+  .node-type-activity .pane-node-field-activity-type .glyphicon {
     margin-right: 10px;
     top: 7px; }
 .node-type-activity .pane-activity-panel-pane-2 {
@@ -13268,9 +11861,7 @@ ol.inline.commerce-checkout-progress {
       float: left; }
     .node-type-activity .panel_sl_right .panel-pane .pane-content .views-row a:hover {
       text-decoration: underline; }
-    .node-type-activity .panel_sl_right .panel-pane .pane-title .glyphicon, .node-type-activity .panel_sl_right .panel-pane .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .node-type-activity .panel_sl_right .panel-pane .pane-title a::before, .node-type-activity .panel_sl_right .panel-pane .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-activity .panel_sl_right .panel-pane .pane-title button::before,
-    .node-type-activity .panel_sl_right .panel-pane .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-    .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .node-type-activity .panel_sl_right .panel-pane .pane-title button::before {
+    .node-type-activity .panel_sl_right .panel-pane .pane-title .glyphicon {
       display: none; }
   .node-type-activity .panel_sl_right .pane-featured-properties-panel-pane-1 {
     /* Zoom In #1 */ }
@@ -13542,13 +12133,13 @@ body.node-type-homepage {
   padding-bottom: 20px;
   /* Zoom In #1 */ }
   .pane-featured-properties-panel-pane-3 .views-row {
-    max-width: 380px; }
+    max-width: 340px; }
   .pane-featured-properties-panel-pane-3 .view-featured-properties.view-display-id-panel_pane_3 {
     margin: 0 auto;
     max-width: 1200px; }
     @media (max-width: 991px) {
       .pane-featured-properties-panel-pane-3 .view-featured-properties.view-display-id-panel_pane_3 {
-        max-width: 380px; } }
+        max-width: 340px; } }
   .pane-featured-properties-panel-pane-3 .views-field-name {
     text-align: center;
     border-bottom: 1px solid rgba(70, 66, 62, 0.2);
@@ -13562,10 +12153,11 @@ body.node-type-homepage {
   .pane-featured-properties-panel-pane-3 .views-field-field-sp-short-description {
     margin: 10px 0;
     text-align: center; }
+  .pane-featured-properties-panel-pane-3 .unslick,
   .pane-featured-properties-panel-pane-3 .slide__content {
     margin: 0 auto;
     display: table;
-    max-width: 380px;
+    max-width: 340px;
     width: 100%;
     padding: 10px;
     background: white;
@@ -13601,7 +12193,7 @@ body.node-type-homepage {
     right: 16px; }
     @media (min-width: 992px) {
       .pane-featured-properties-panel-pane-3 .slick-next.slick-arrow {
-        right: 25px; } }
+        right: 45px !important; } }
   .pane-featured-properties-panel-pane-3 .slick-prev.slick-arrow {
     background: url("../images/arrow_left.png") 0 50% no-repeat;
     background: url("../images/arrow_left.svg") center center no-repeat, linear-gradient(transparent, transparent);
@@ -13617,7 +12209,7 @@ body.node-type-homepage {
     left: 16px; }
     @media (min-width: 992px) {
       .pane-featured-properties-panel-pane-3 .slick-prev.slick-arrow {
-        left: 25px; } }
+        left: 45px !important; } }
   .pane-featured-properties-panel-pane-3 .views-field-starting-price {
     position: absolute;
     right: 10px;
@@ -14065,6 +12657,26 @@ body.node-type-homepage {
   text-align: right;
   margin: 25px 0; }
   .page-taxonomy-area .field-name-field-field-link-to-area-blog a {
+    display: inline-block;
+    margin-bottom: 0;
+    text-align: center;
+    vertical-align: middle;
+    touch-action: manipulation;
+    cursor: pointer;
+    background-image: none;
+    border: 1px solid transparent;
+    white-space: nowrap;
+    line-height: 1.42857;
+    border-radius: 4px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    border-width: 0 1px 4px 1px;
+    font-size: 12px;
+    font-weight: 400;
+    text-transform: uppercase;
+    padding: 6px 10px 4px;
     color: #FFFFFF;
     background-color: #127BA3;
     border-color: #158CBA; }
@@ -14096,7 +12708,25 @@ body.node-type-homepage {
   padding: 0 20px;
   margin-bottom: 35px; }
 .page-taxonomy-area .panel_sl_content {
-  float: none; }
+  float: none;
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 15px;
+  padding-right: 15px; }
+  .page-taxonomy-area .panel_sl_content:before, .page-taxonomy-area .panel_sl_content:after {
+    content: " ";
+    display: table; }
+  .page-taxonomy-area .panel_sl_content:after {
+    clear: both; }
+  @media (min-width: 768px) {
+    .page-taxonomy-area .panel_sl_content {
+      width: 750px; } }
+  @media (min-width: 992px) {
+    .page-taxonomy-area .panel_sl_content {
+      width: 970px; } }
+  @media (min-width: 1200px) {
+    .page-taxonomy-area .panel_sl_content {
+      width: 1170px; } }
 @media (max-width: 992px) and (min-width: 768px) {
   .page-taxonomy-area #property-bat-facets-availability .bat-date-range {
     width: 70%; }
@@ -14422,9 +13052,7 @@ body.node-type-homepage {
     .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title {
       border-bottom: 1px solid #ececec;
       padding-bottom: 15px; }
-      .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title .glyphicon, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title a::before, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title button::before,
-      .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-      .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title button::before {
+      .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-title .glyphicon {
         display: none; }
     .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .pane-content {
       padding: 15px 10px; }
@@ -14486,9 +13114,7 @@ body.node-type-homepage {
     .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title {
       border-bottom: 1px solid #ececec;
       padding-bottom: 15px; }
-      .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .glyphicon, .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title a::before, .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title button::before,
-      .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
-      .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title button::before {
+      .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-title .glyphicon {
         display: none; }
     .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-content .field-item.even,
     .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities .pane-content .field-item.odd {
@@ -14572,11 +13198,7 @@ body.node-type-homepage {
     margin-left: 10%;
     margin-right: 10%;
     padding: 1% 2%; } }
-.page-conversation #modal-content .btn, .page-conversation #modal-content .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation #modal-content .checkout-continue, .page-conversation #modal-content .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation #modal-content .checkout-back,
-.page-conversation #modal-content .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-.page-checkout fieldset.panel-default.checkout-buttons .page-conversation #modal-content .checkout-cancel, .page-conversation #modal-content .page-blog .pager-load-more a, .page-blog .pager-load-more .page-conversation #modal-content a,
-.page-conversation #modal-content .page-blog .roomify-add-button,
-.page-blog .page-conversation #modal-content .roomify-add-button, .page-conversation #modal-content .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-conversation #modal-content a, .page-conversation #modal-content .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-conversation #modal-content button {
+.page-conversation #modal-content .btn {
   border-radius: 5px; }
 .page-conversation #modal-content .btn-primary {
   margin-left: 10px; }
@@ -14591,11 +13213,7 @@ body.node-type-homepage {
   .page-conversation .pane-send-message .grippie,
   .page-conversation .pane-send-message .control-label {
     display: none; }
-  .page-conversation .pane-send-message .btn, .page-conversation .pane-send-message .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .pane-send-message .checkout-continue, .page-conversation .pane-send-message .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .pane-send-message .checkout-back,
-  .page-conversation .pane-send-message .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-  .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .pane-send-message .checkout-cancel, .page-conversation .pane-send-message .page-blog .pager-load-more a, .page-blog .pager-load-more .page-conversation .pane-send-message a,
-  .page-conversation .pane-send-message .page-blog .roomify-add-button,
-  .page-blog .page-conversation .pane-send-message .roomify-add-button, .page-conversation .pane-send-message .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-conversation .pane-send-message a, .page-conversation .pane-send-message .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-conversation .pane-send-message button {
+  .page-conversation .pane-send-message .btn {
     float: right;
     border-radius: 5px; }
 .page-conversation .pane-activity-stream {
@@ -14707,26 +13325,8 @@ body.node-type-homepage {
   .page-conversation .entity-bat-booking .book-this-button,
   .page-conversation .entity-bat-booking .button {
     float: right; }
-    .page-conversation .entity-bat-booking .book-this-button .btn, .page-conversation .entity-bat-booking .book-this-button .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .entity-bat-booking .book-this-button .checkout-continue, .page-conversation .entity-bat-booking .book-this-button .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .entity-bat-booking .book-this-button .checkout-back,
-    .page-conversation .entity-bat-booking .book-this-button .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .entity-bat-booking .book-this-button .checkout-cancel, .page-conversation .entity-bat-booking .book-this-button .page-blog .pager-load-more a, .page-blog .pager-load-more .page-conversation .entity-bat-booking .book-this-button a,
-    .page-conversation .entity-bat-booking .book-this-button .page-blog .roomify-add-button,
-    .page-blog .page-conversation .entity-bat-booking .book-this-button .roomify-add-button, .page-conversation .entity-bat-booking .book-this-button .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-conversation .entity-bat-booking .book-this-button a, .page-conversation .entity-bat-booking .book-this-button .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-conversation .entity-bat-booking .book-this-button button,
-    .page-conversation .entity-bat-booking .button .btn,
-    .page-conversation .entity-bat-booking .button .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .entity-bat-booking .button .checkout-continue,
-    .page-conversation .entity-bat-booking .button .page-checkout fieldset.panel-default.checkout-buttons .checkout-back,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .entity-bat-booking .button .checkout-back,
-    .page-conversation .entity-bat-booking .button .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-    .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .entity-bat-booking .button .checkout-cancel,
-    .page-conversation .entity-bat-booking .button .page-blog .pager-load-more a,
-    .page-blog .pager-load-more .page-conversation .entity-bat-booking .button a,
-    .page-conversation .entity-bat-booking .button .page-blog .roomify-add-button,
-    .page-blog .page-conversation .entity-bat-booking .button .roomify-add-button,
-    .page-conversation .entity-bat-booking .button .page-taxonomy-area .field-name-field-field-link-to-area-blog a,
-    .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-conversation .entity-bat-booking .button a,
-    .page-conversation .entity-bat-booking .button .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button,
-    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-conversation .entity-bat-booking .button button {
+    .page-conversation .entity-bat-booking .book-this-button .btn,
+    .page-conversation .entity-bat-booking .button .btn {
       border-radius: 5px; }
     .page-conversation .entity-bat-booking .book-this-button form,
     .page-conversation .entity-bat-booking .button form {
@@ -14752,11 +13352,7 @@ body.node-type-homepage {
     float: right; }
     .page-conversation .enquiry-item .right .button {
       display: inline-block; }
-      .page-conversation .enquiry-item .right .button .btn, .page-conversation .enquiry-item .right .button .page-checkout fieldset.panel-default.checkout-buttons .checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .enquiry-item .right .button .checkout-continue, .page-conversation .enquiry-item .right .button .page-checkout fieldset.panel-default.checkout-buttons .checkout-back, .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .enquiry-item .right .button .checkout-back,
-      .page-conversation .enquiry-item .right .button .page-checkout fieldset.panel-default.checkout-buttons .checkout-cancel,
-      .page-checkout fieldset.panel-default.checkout-buttons .page-conversation .enquiry-item .right .button .checkout-cancel, .page-conversation .enquiry-item .right .button .page-blog .pager-load-more a, .page-blog .pager-load-more .page-conversation .enquiry-item .right .button a,
-      .page-conversation .enquiry-item .right .button .page-blog .roomify-add-button,
-      .page-blog .page-conversation .enquiry-item .right .button .roomify-add-button, .page-conversation .enquiry-item .right .button .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog .page-conversation .enquiry-item .right .button a, .page-conversation .enquiry-item .right .button .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button, .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit .page-conversation .enquiry-item .right .button button {
+      .page-conversation .enquiry-item .right .button .btn {
         border-radius: 5px; }
       .page-conversation .enquiry-item .right .button.make-offer {
         margin-left: 10px; }
@@ -15213,7 +13809,230 @@ body.page-single-property-listing {
           text-transform: capitalize;
           padding: 6px;
           font-size: 14px;
-          width: 100%; }
+          width: 100%;
+          color: #fff;
+          background-color: #FF4136;
+          border-color: #ff291d; }
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.focus {
+            color: #fff;
+            background-color: #ff1103;
+            border-color: #9c0900; }
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:hover {
+            color: #fff;
+            background-color: #ff1103;
+            border-color: #de0c00; }
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.active, .open > body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.dropdown-toggle {
+            color: #fff;
+            background-color: #ff1103;
+            border-color: #de0c00; }
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.active:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.active:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.active.focus, .open > body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.dropdown-toggle:hover, .open > body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.dropdown-toggle:focus, .open > body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.dropdown-toggle.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active.focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.active:hover,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.active:focus,
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.active.focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.dropdown-toggle:hover, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.dropdown-toggle:focus, .open >
+            body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.dropdown-toggle.focus {
+              color: #fff;
+              background-color: #de0c00;
+              border-color: #9c0900; }
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:active, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.active, .open > body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:active,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:active,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:active,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.dropdown-toggle,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:active,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.active, .open >
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.dropdown-toggle {
+            background-image: none; }
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.disabled:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.disabled:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.disabled.focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit[disabled]:hover, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit[disabled]:focus, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit[disabled].focus, fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:hover, fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit:focus, fieldset[disabled] body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.disabled:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.disabled:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.disabled.focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit[disabled]:hover,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit[disabled]:focus,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit[disabled].focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:hover, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit:focus, fieldset[disabled]
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit.focus {
+            background-color: #FF4136;
+            border-color: #ff291d; }
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit .form-submit .badge,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .locanda-availability-search-submit .form-submit .badge,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-availability-submit .form-submit .badge,
+          body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .search-submit .form-submit .badge,
+          body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit .form-submit .badge,
+          body.page-single-property-listing .pane-locanda-availability-search form .locanda-availability-search-submit .form-submit .badge,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-availability-submit .form-submit .badge,
+          body.page-single-property-listing .pane-locanda-availability-search form .search-submit .form-submit .badge {
+            color: #FF4136;
+            background-color: #fff; }
       body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .listing-availability-search-submit,
       body.page-single-property-listing .pane-locanda-availability-search form .listing-availability-search-submit {
         position: relative;
@@ -15256,17 +14075,17 @@ body.page-single-property-listing {
         body.page-single-property-listing .pane-locanda-availability-search form input.form-text::-webkit-input-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form select.form-text::-webkit-input-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form .form-control.form-text::-webkit-input-placeholder {
-          color: #353535; }
+          color: #c9c9c9; }
         body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form input.form-text::-moz-placeholder, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form select.form-text::-moz-placeholder, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .form-control.form-text::-moz-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form input.form-text::-moz-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form select.form-text::-moz-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form .form-control.form-text::-moz-placeholder {
-          color: #353535; }
+          color: #c9c9c9; }
         body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form input.form-text:-moz-placeholder, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form select.form-text:-moz-placeholder, body.page-single-property-listing .pane-roomify-listing-availability-search-block-roomify-listing-search form .form-control.form-text:-moz-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form input.form-text:-moz-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form select.form-text:-moz-placeholder,
         body.page-single-property-listing .pane-locanda-availability-search form .form-control.form-text:-moz-placeholder {
-          color: #353535; }
+          color: #c9c9c9; }
   body.page-single-property-listing .pane-roomify-property-field-sp-highlight-image1 img,
   body.page-single-property-listing .pane-roomify-property-field-sp-highlight-image2 img,
   body.page-single-property-listing .pane-roomify-property-field-sp-highlight-image3 img,
@@ -15303,6 +14122,32 @@ body.page-single-property-listing {
     @media (max-width: 480px) {
       body.page-single-property-listing .pane-roomify-property-field-sp-short-description {
         margin-bottom: 0; } }
+  body.page-single-property-listing .panel-content-wrapper,
+  body.page-single-property-listing .panel-content-bottom {
+    margin-right: auto;
+    margin-left: auto;
+    padding-left: 15px;
+    padding-right: 15px; }
+    body.page-single-property-listing .panel-content-wrapper:before, body.page-single-property-listing .panel-content-wrapper:after,
+    body.page-single-property-listing .panel-content-bottom:before,
+    body.page-single-property-listing .panel-content-bottom:after {
+      content: " ";
+      display: table; }
+    body.page-single-property-listing .panel-content-wrapper:after,
+    body.page-single-property-listing .panel-content-bottom:after {
+      clear: both; }
+    @media (min-width: 768px) {
+      body.page-single-property-listing .panel-content-wrapper,
+      body.page-single-property-listing .panel-content-bottom {
+        width: 750px; } }
+    @media (min-width: 992px) {
+      body.page-single-property-listing .panel-content-wrapper,
+      body.page-single-property-listing .panel-content-bottom {
+        width: 970px; } }
+    @media (min-width: 1200px) {
+      body.page-single-property-listing .panel-content-wrapper,
+      body.page-single-property-listing .panel-content-bottom {
+        width: 1170px; } }
   body.page-single-property-listing .panel-content-bottom {
     margin-bottom: 70px;
     margin-top: 35px; }
@@ -15416,11 +14261,7 @@ body.page-single-property-listing {
         display: inline-block;
         width: 100%;
         margin-top: 20px; }
-        body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a.btn, body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .page-checkout fieldset.panel-default.checkout-buttons a.checkout-continue, .page-checkout fieldset.panel-default.checkout-buttons body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a.checkout-continue, body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .page-checkout fieldset.panel-default.checkout-buttons a.checkout-back, .page-checkout fieldset.panel-default.checkout-buttons body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a.checkout-back,
-        body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .page-checkout fieldset.panel-default.checkout-buttons a.checkout-cancel,
-        .page-checkout fieldset.panel-default.checkout-buttons body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a.checkout-cancel, body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .page-blog .pager-load-more a, .page-blog .pager-load-more body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a,
-        body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .page-blog a.roomify-add-button,
-        .page-blog body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a.roomify-add-button, body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .page-taxonomy-area .field-name-field-field-link-to-area-blog a, .page-taxonomy-area .field-name-field-field-link-to-area-blog body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a {
+        body.page-single-property-listing .view-property-travel .views-row .views-field-book-this a.btn {
           position: relative;
           float: left;
           width: 33.33333%;

--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -15275,6 +15275,9 @@ body.page-single-property-listing {
     font-size: 26px;
     text-align: center;
     margin: 50px 0; }
+    @media (max-width: 480px) {
+      body.page-single-property-listing .pane-roomify-property-field-sp-short-description {
+        margin-bottom: 0; } }
   body.page-single-property-listing .panel-content-bottom {
     margin-bottom: 70px;
     margin-top: 35px; }
@@ -15286,9 +15289,7 @@ body.page-single-property-listing {
         body.page-single-property-listing .panel-content-bottom .ui-tabs .ui-tabs-nav li.ui-state-default {
           border-width: 1px;
           border-bottom: 0;
-          float: right; }
-          body.page-single-property-listing .panel-content-bottom .ui-tabs .ui-tabs-nav li.ui-state-default:first-child {
-            margin-right: 0; } }
+          float: left; } }
     body.page-single-property-listing .panel-content-bottom #property-description-tab {
       background: url("../images/description.png") center center no-repeat;
       background: url("../images/description.svg") center center no-repeat, linear-gradient(transparent, transparent);
@@ -15348,24 +15349,15 @@ body.page-single-property-listing {
       opacity: 0.5;
       bottom: 1px;
       position: relative; }
-  body.page-single-property-listing .casa-property-description {
-    display: inline-block;
-    width: 100%;
-    padding: 30px;
-    background: white;
-    border-radius: 2px;
-    border: 1px solid #ececec;
-    margin-top: 52px;
-    margin-bottom: 50px; }
   body.page-single-property-listing .view-property-travel {
     display: inline-block;
     width: 100%;
-    padding: 30px;
-    background: white;
-    border-radius: 2px;
-    border: 1px solid #ececec;
-    margin-top: 52px;
-    margin-bottom: 50px; }
+    padding: 18px;
+    margin-top: 40px;
+    margin-bottom: 40px; }
+    @media (max-width: 480px) {
+      body.page-single-property-listing .view-property-travel {
+        padding: 0; } }
     body.page-single-property-listing .view-property-travel .views-row {
       display: inline-block;
       width: 100%;
@@ -15379,12 +15371,20 @@ body.page-single-property-listing {
         font-size: 20px;
         margin-bottom: 20px;
         display: inline-block;
-        font-weight: 400; }
+        color: initial; }
+        @media (min-width: 992px) {
+          body.page-single-property-listing .view-property-travel .views-row .views-field-name a {
+            font-size: 24px; } }
+      body.page-single-property-listing .view-property-travel .views-row .views-field-field-st-description {
+        font-size: 16px; }
       body.page-single-property-listing .view-property-travel .views-row .views-field-field-st-gallery {
         display: inline-block;
         float: left;
         margin-right: 20px;
-        max-width: 250px; }
+        max-width: 360px; }
+        @media (max-width: 480px) {
+          body.page-single-property-listing .view-property-travel .views-row .views-field-field-st-gallery {
+            margin-bottom: 15px; } }
         body.page-single-property-listing .view-property-travel .views-row .views-field-field-st-gallery img {
           border-radius: 2px; }
       body.page-single-property-listing .view-property-travel .views-row .views-field-book-this {
@@ -15402,7 +15402,8 @@ body.page-single-property-listing {
           min-height: 1px;
           padding-left: 15px;
           padding-right: 15px;
-          float: right; }
+          float: right;
+          max-width: 200px; }
         body.page-single-property-listing .view-property-travel .views-row .views-field-book-this .info {
           position: relative;
           float: left;

--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -9783,23 +9783,30 @@ body.toggled #close-sidebar-wrapper {
           background: #b81621; }
         .page-listing .pane-roomify-owner-social-pages .pane-content .rsp-social-icon.rsp-googleplus {
           background: #e93f2e; }
-  .page-listing .pane-roomify-property-field-sp-highlight-image1 img,
-  .page-listing .pane-roomify-property-field-sp-highlight-image2 img,
-  .page-listing .pane-roomify-property-field-sp-highlight-image3 img,
-  .page-listing .pane-roomify-property-field-sp-highlight-image1-cap img,
-  .page-listing .pane-roomify-property-field-sp-highlight-image2-cap img,
-  .page-listing .pane-roomify-property-field-sp-highlight-image3-cap img {
-    margin: 60px auto 10px auto;
-    border: 1px solid #ececec;
-    border-radius: 2px; }
-  .page-listing .pane-roomify-property-field-sp-highlight-image1 .field-type-text,
-  .page-listing .pane-roomify-property-field-sp-highlight-image2 .field-type-text,
-  .page-listing .pane-roomify-property-field-sp-highlight-image3 .field-type-text,
-  .page-listing .pane-roomify-property-field-sp-highlight-image1-cap .field-type-text,
-  .page-listing .pane-roomify-property-field-sp-highlight-image2-cap .field-type-text,
-  .page-listing .pane-roomify-property-field-sp-highlight-image3-cap .field-type-text {
-    margin-bottom: 50px;
-    text-align: center; }
+  .page-listing .pane-roomify-property-field-sp-highlight-image1,
+  .page-listing .pane-roomify-property-field-sp-highlight-image2,
+  .page-listing .pane-roomify-property-field-sp-highlight-image3,
+  .page-listing .pane-roomify-property-field-sp-highlight-image1-cap,
+  .page-listing .pane-roomify-property-field-sp-highlight-image2-cap,
+  .page-listing .pane-roomify-property-field-sp-highlight-image3-cap {
+    font-weight: 500; }
+    .page-listing .pane-roomify-property-field-sp-highlight-image1 img,
+    .page-listing .pane-roomify-property-field-sp-highlight-image2 img,
+    .page-listing .pane-roomify-property-field-sp-highlight-image3 img,
+    .page-listing .pane-roomify-property-field-sp-highlight-image1-cap img,
+    .page-listing .pane-roomify-property-field-sp-highlight-image2-cap img,
+    .page-listing .pane-roomify-property-field-sp-highlight-image3-cap img {
+      margin: 60px auto 10px auto;
+      border: 1px solid #ececec;
+      border-radius: 2px; }
+    .page-listing .pane-roomify-property-field-sp-highlight-image1 .field-type-text,
+    .page-listing .pane-roomify-property-field-sp-highlight-image2 .field-type-text,
+    .page-listing .pane-roomify-property-field-sp-highlight-image3 .field-type-text,
+    .page-listing .pane-roomify-property-field-sp-highlight-image1-cap .field-type-text,
+    .page-listing .pane-roomify-property-field-sp-highlight-image2-cap .field-type-text,
+    .page-listing .pane-roomify-property-field-sp-highlight-image3-cap .field-type-text {
+      margin-bottom: 50px;
+      text-align: center; }
   .page-listing .pane-roomify-property-field-sp-amenities .field-name-field-sp-amenities .field-item.even,
   .page-listing .pane-roomify-property-field-sp-amenities .field-name-field-sp-amenities .field-item.odd {
     display: inline-block;
@@ -9845,11 +9852,11 @@ body.toggled #close-sidebar-wrapper {
               display: block; } }
           .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td.views-field-field-st-gallery a {
             color: #127ba3;
+            font-size: 22px;
             text-decoration: none; }
           .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td.views-field-field-st-gallery img {
             max-width: 140px;
             border-radius: 2px;
-            border: 1px solid #ECECEC;
             margin-left: 25px;
             margin-top: 15px; }
         .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td.views-field-field-st-description {
@@ -9860,7 +9867,7 @@ body.toggled #close-sidebar-wrapper {
             font-style: normal; }
             @media (min-width: 992px) {
               .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td.views-field-field-st-description .type-description {
-                margin-top: 45px; } }
+                margin-top: 65px; } }
             .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td.views-field-field-st-description .type-description p {
               line-height: 20px; }
             @media (max-width: 768px) {
@@ -9898,10 +9905,9 @@ body.toggled #close-sidebar-wrapper {
             width: 25px;
             height: 25px; }
           .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td.views-field-book-this a {
-            font-size: 15px;
-            width: 120px;
+            font-size: 12px;
+            width: 125px;
             text-align: center;
-            color: white;
             color: #FFFFFF;
             background-color: #127BA3;
             border-color: #158CBA; }
@@ -9936,20 +9942,23 @@ body.toggled #close-sidebar-wrapper {
             color: #848484; }
         .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner {
           margin: 10px 0;
+          padding: 30px;
+          display: block;
           border-radius: 2px;
           border: 1px solid #ececec;
-          background: #f8f8f8; }
+          background: #fafafa; }
+          .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner .footable-row-detail-value {
+            line-height: 2em; }
           .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner .footable-row-detail-row {
             margin: 8px 2%;
             display: inline-block;
             width: 100%; }
             .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner .footable-row-detail-row:first-child {
-              width: 100%;
-              margin-top: 25px;
               margin-bottom: 10px;
-              padding: 0 10px;
               font-weight: 400;
               font-size: 15px; }
+              .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner .footable-row-detail-row:first-child .footable-row-detail-name {
+                padding-right: 0; }
               .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner .footable-row-detail-row:first-child .type-description {
                 font-style: normal; }
                 .page-listing .pane-property-travel-panel-pane-3 .views-table tbody tr td .footable-row-detail-inner .footable-row-detail-row:first-child .type-description p {
@@ -14454,6 +14463,15 @@ body.node-type-homepage {
     .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-date-range .end-date .form-type-textfield label,
     .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-date-range .end-date .help-block {
       display: none; }
+    .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .form-item-group-size {
+      width: 100%;
+      margin-bottom: 25px; }
+      .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .form-item-group-size select {
+        width: 100%;
+        border-radius: 2px;
+        -webkit-border-radius: 2px;
+        color: #353535;
+        font-size: 15px; }
     .page-room-type .panel_sl_left .panel-pane.pane-type-availability-search .bat-type-availability-search-submit button {
       width: 100%; }
   .page-room-type .panel_sl_left .panel-pane.pane-bat-type-field-st-amenities {

--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -8463,94 +8463,71 @@ blockquote {
           width: 30%;
           text-align: right; }
 
-.roomify-sidebar-link {
-  margin-left: 20px;
-  width: 30px;
-  height: 30px;
-  padding: 0; }
-  .roomify-sidebar-link a {
-    width: 30px;
-    height: 30px;
-    display: inline-block; }
-    @media (min-width: 768px) {
-      .roomify-sidebar-link a {
-        position: relative;
-        top: 8px; } }
-  @media (max-width: 767px) {
-    .roomify-sidebar-link {
-      margin: 0 0 30px 0; } }
-
-body header.roomify-header .navbar-collapse nav ul.navbar-nav > li > a {
-  color: #484848; }
-
-body header.roomify-header .navbar-collapse nav ul.navbar-nav > li > a:hover {
-  color: #000000; }
-
-body header.roomify-header {
-  min-height: 70px;
-  background: #ffffff;
+header.roomify-header {
+  margin-bottom: 0;
   border-radius: 0;
-  border-right: 0;
-  border-left: 0; }
-  @media (min-width: 768px) and (max-width: 992px) {
-    body header.roomify-header .navbar-collapse nav ul.nav li a {
-      font-size: 12px; } }
-  body header.roomify-header .navbar nav ul.navbar-nav > li > a:hover {
-    color: #333333; }
+  border-left: 0;
+  border-right: 0; }
   @media (min-width: 768px) {
-    body header.roomify-header .container, body header.roomify-header .messages-container, body header.roomify-header .page-taxonomy-area .panel_sl_content, .page-taxonomy-area body header.roomify-header .panel_sl_content, body.page-single-property-listing header.roomify-header .panel-content-wrapper,
-    body.page-single-property-listing header.roomify-header .panel-content-bottom {
-      padding: 0; } }
-  body header.roomify-header a.logo {
-    margin-top: 0;
-    margin-bottom: 0; }
-    body header.roomify-header a.logo img {
-      height: 66px;
-      margin: 2px 0; }
-  body header.roomify-header a.name {
-    font-size: 22px;
-    margin-top: 10px; }
-  body header.roomify-header .navbar-collapse.collapse {
-    float: right;
-    margin-top: 15px; }
-    body header.roomify-header .navbar-collapse.collapse.collasping, body header.roomify-header .navbar-collapse.collapse.in {
-      float: none; }
-  body header.roomify-header .navbar-toggle {
-    position: absolute;
-    top: 20px;
-    right: 30px;
-    float: none;
-    margin-right: 0;
-    padding: 0;
-    margin: 0;
-    background-color: transparent;
-    background-image: none;
-    border: 0;
-    border-radius: 0;
-    z-index: 9; }
-    body header.roomify-header .navbar-toggle .icon-bar {
-      height: 3px; }
-    body header.roomify-header .navbar-toggle:hover, body header.roomify-header .navbar-toggle:focus {
-      background: transparent; }
-
-.navbar-nav > li > .dropdown-menu {
-  margin-top: 6px;
-  background: white;
-  min-width: 220px;
-  border: 2px solid #e7e7e7;
-  padding: 0; }
-  .navbar-nav > li > .dropdown-menu li {
-    border-bottom: 1px solid #f8f8f8; }
-    .navbar-nav > li > .dropdown-menu li :last-child {
-      border: none; }
-    .navbar-nav > li > .dropdown-menu li a {
-      font-size: 14px;
-      padding: 10px;
-      background: white;
-      color: #333333; }
-      .navbar-nav > li > .dropdown-menu li a:hover, .navbar-nav > li > .dropdown-menu li a:focus {
-        background: #F8F8F8;
-        color: #333333; }
+    header.roomify-header .container:first-child, header.roomify-header .messages-container:first-child, header.roomify-header .page-taxonomy-area .panel_sl_content:first-child, .page-taxonomy-area header.roomify-header .panel_sl_content:first-child, header.roomify-header body.page-single-property-listing .panel-content-wrapper:first-child, body.page-single-property-listing header.roomify-header .panel-content-wrapper:first-child,
+    header.roomify-header body.page-single-property-listing .panel-content-bottom:first-child,
+    body.page-single-property-listing header.roomify-header .panel-content-bottom:first-child {
+      padding-left: 0;
+      padding-right: 0; } }
+  header.roomify-header .navbar-header {
+    width: 100%;
+    display: table;
+    margin: 0 auto;
+    min-height: 60px; }
+  header.roomify-header .roomify-site-menu {
+    position: relative; }
+    header.roomify-header .roomify-site-menu .inner {
+      padding-left: 0; }
+    header.roomify-header .roomify-site-menu .navbar-toggle {
+      display: block;
+      border: 0;
+      background: transparent;
+      top: 3px;
+      position: relative;
+      float: left; }
+      @media (max-width: 767px) {
+        header.roomify-header .roomify-site-menu .navbar-toggle {
+          top: 0; } }
+  header.roomify-header .roomify-site-name {
+    margin-top: 2px; }
+    header.roomify-header .roomify-site-name a.name {
+      text-align: center;
+      display: inline-block;
+      font-size: 22px;
+      margin-top: 5px;
+      width: 100%; }
+    header.roomify-header .roomify-site-name a.logo {
+      display: table;
+      margin: 8px auto;
+      max-height: 60px; }
+  header.roomify-header .roomify-user-menu {
+    position: relative; }
+    header.roomify-header .roomify-user-menu .roomify-sidebar-link {
+      padding: 0; }
+      header.roomify-header .roomify-user-menu .roomify-sidebar-link a {
+        width: 30px;
+        height: 30px;
+        display: inline-block;
+        width: 100%;
+        position: relative; }
+        @media (min-width: 768px) {
+          header.roomify-header .roomify-user-menu .roomify-sidebar-link a {
+            position: relative; } }
+        header.roomify-header .roomify-user-menu .roomify-sidebar-link a svg {
+          height: 28px;
+          width: 28px;
+          right: 0;
+          position: absolute; }
+      @media (max-width: 767px) {
+        header.roomify-header .roomify-user-menu .roomify-sidebar-link {
+          margin: 0 0 30px 0; } }
+    header.roomify-header .roomify-user-menu .inner {
+      padding-right: 0; }
 
 .roomify-language-switcher {
   position: relative;
@@ -8682,10 +8659,10 @@ body header.roomify-header {
 
 body {
   padding-right: 0;
-  -webkit-transition: 70ms all linear;
-  -moz-transition: 70ms all linear;
-  -ms-transition: 70ms all linear;
-  -o-transition: 70ms all linear; }
+  -webkit-transition: 60ms all linear;
+  -moz-transition: 60ms all linear;
+  -ms-transition: 60ms all linear;
+  -o-transition: 60ms all linear; }
   body #sidebar-wrapper {
     z-index: 1000;
     position: fixed;
@@ -8696,19 +8673,17 @@ body {
     overflow-y: auto;
     background: #000;
     overflow-x: hidden;
-    -webkit-transition: 70ms all linear;
-    -moz-transition: 70ms all linear;
-    -ms-transition: 70ms all linear;
-    -o-transition: 70ms all linear;
-    -webkit-transition: 2ms width linear;
-    -moz-transition: 2ms width linear;
-    -ms-transition: 2ms width linear;
-    -o-transition: 2ms width linear; }
+    -webkit-transition: 60ms all linear;
+    -moz-transition: 60ms all linear;
+    -ms-transition: 60ms all linear;
+    -o-transition: 60ms all linear; }
     body #sidebar-wrapper .close-sidebar {
       border-bottom: 0;
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px; }
+      body #sidebar-wrapper .close-sidebar:after {
+        display: none; }
     body #sidebar-wrapper #close-sidebar-icon {
       background: url("../images/close.png") center center no-repeat;
       margin-right: 20px;
@@ -8731,20 +8706,29 @@ body {
     body .sidebar-nav .panel-pane {
       display: inline-block;
       width: 100%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
-      padding-bottom: 30px; }
-      body .sidebar-nav .panel-pane:last-child {
-        border-bottom: none; }
+      margin-bottom: 10px;
+      padding-bottom: 30px;
+      min-width: 320px; }
+      body .sidebar-nav .panel-pane:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px; }
+      body .sidebar-nav .panel-pane:last-child:after {
+        display: none; }
       body .sidebar-nav .panel-pane .pane-title {
         border-bottom: 0;
         text-align: left;
         width: 100%;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
-        font-size: 22px;
-        text-align: center; }
+        padding: 5px 15px;
+        font-size: 22px; }
     body .sidebar-nav .pane-roomify-sidebar-user-menu .pane-title {
       margin-bottom: 5px;
       font-size: 22px; }
@@ -8842,7 +8826,7 @@ body {
       body .sidebar-nav .pane-commerce-cart-cart .glyphicon, body .sidebar-nav .pane-commerce-cart-cart .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-commerce-cart-cart a::before, body .sidebar-nav .pane-commerce-cart-cart .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before,
       body .sidebar-nav .pane-commerce-cart-cart .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
       .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-commerce-cart-cart button::before {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -8876,16 +8860,17 @@ body {
       font-weight: 400;
       border-bottom: 0;
       font-size: 22px;
-      text-align: center;
       width: 100%; }
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .glyphicon, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a::before, body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before,
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
       .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title button::before {
         display: inline-block;
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 6px;
         z-index: 99;
-        color: #03A9F4; }
+        color: #03A9F4;
+        top: 2px;
+        right: 4px; }
       body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a {
         color: white; }
         body .sidebar-nav .pane-favorite-properties-sidebar-favorites .pane-title a:hover {
@@ -8926,14 +8911,15 @@ body {
         color: white;
         font-weight: 400;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%; }
         body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .glyphicon, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .pane-roomify-property-flag-favorites-link .flag-favorites a::before, .pane-roomify-property-flag-favorites-link .flag-favorites body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title a::before, body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before, .page-conversation-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before,
         body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit button::before,
         .page-booking #roomify-accommodation-booking-current-search-form .current-search-item.current-search-submit body .sidebar-nav .pane-dashboard-guest-stays-panel-pane-2 .pane-title button::before {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4; }
@@ -8966,12 +8952,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
-        color: white;
-        text-align: center; }
+        color: white; }
       body .sidebar-nav .pane-my-stays-panel-pane-1 .view-my-stays .views-row {
         display: inline-block;
         width: 100%;
@@ -9012,7 +8998,9 @@ body {
       padding-right: 300px;
       margin-left: -300px; }
       body.toggled #sidebar-wrapper {
-        width: 300px; } }
+        width: 300px; }
+      body.toggled .sidebar-nav .panel-pane {
+        min-width: 280px; } }
 
 .roomify-sidebar-link a {
   font-size: 15px;
@@ -9031,14 +9019,87 @@ body.toggled #close-sidebar-wrapper {
   background: rgba(0, 0, 0, 0.35);
   height: 100%;
   cursor: pointer;
-  -webkit-transition: 70ms all linear;
-  -moz-transition: 70ms all linear;
-  -ms-transition: 70ms all linear;
-  -o-transition: 70ms all linear;
-  -webkit-transition: 2ms width linear;
-  -moz-transition: 2ms width linear;
-  -ms-transition: 2ms width linear;
-  -o-transition: 2ms width linear; }
+  -webkit-transition: 60ms all linear;
+  -moz-transition: 60ms all linear;
+  -ms-transition: 60ms all linear;
+  -o-transition: 60ms all linear; }
+
+/* The Overlay (background) */
+.roomify-overlay {
+  /* Height & width depends on how you want to reveal the overlay (see JS below) */
+  height: 100%;
+  width: 100%;
+  position: fixed;
+  /* Stay in place */
+  z-index: 100;
+  /* Sit on top */
+  left: 0;
+  top: 0;
+  display: none;
+  background-color: black;
+  /* Black fallback color */
+  background-color: rgba(0, 0, 0, 0.92);
+  /* Black w/opacity */
+  overflow-x: hidden;
+  /* Disable horizontal scroll */
+  opacity: 0;
+  -webkit-transition: 200ms opacity ease-in-out;
+  -moz-transition: 200ms opacity ease-in-out;
+  -ms-transition: 200ms opacity ease-in-out;
+  -o-transition: 200ms opacity ease-in-out; }
+  .roomify-overlay .overlay-content {
+    position: relative;
+    top: 20%;
+    /* 25% from the top */
+    width: 100%;
+    /* 100% width */
+    text-align: center;
+    /* Centered text/links */
+    margin-top: 30px;
+    /* 30px top margin to avoid conflict with the close button on smaller screens */ }
+    .roomify-overlay .overlay-content a {
+      padding: 15px 8px;
+      text-decoration: none;
+      font-size: 36px;
+      color: #818181;
+      display: block;
+      /* Display block instead of inline */
+      transition: 0.3s;
+      /* Transition effects on hover (color) */ }
+      .roomify-overlay .overlay-content a:hover, .roomify-overlay .overlay-content a:focus {
+        color: #f1f1f1; }
+    .roomify-overlay .overlay-content .menu li:hover, .roomify-overlay .overlay-content .menu li:focus {
+      background: transparent; }
+    .roomify-overlay .overlay-content .menu li .dropdown-menu {
+      max-width: 360px;
+      margin: 0 auto;
+      left: 0;
+      right: 0;
+      border-radius: 0;
+      background: rgba(0, 0, 0, 0.9);
+      border: 0; }
+      .roomify-overlay .overlay-content .menu li .dropdown-menu li a {
+        font-size: 22px;
+        text-align: center;
+        padding: 8px; }
+    .roomify-overlay .overlay-content .menu li .active > a,
+    .roomify-overlay .overlay-content .menu li .active > a:hover,
+    .roomify-overlay .overlay-content .menu li .active > a:focus {
+      background-color: transparent; }
+    .roomify-overlay .overlay-content .menu li a:hover, .roomify-overlay .overlay-content .menu li a:focus {
+      background: transparent; }
+  .roomify-overlay .closebtn {
+    position: absolute;
+    top: 20px;
+    right: 45px;
+    font-size: 60px; }
+  @media screen and (max-height: 450px) {
+    .roomify-overlay a {
+      font-size: 20px; }
+    .roomify-overlay .closebtn {
+      font-size: 40px;
+      top: 15px;
+      right: 35px; } }
 
 .pane-roomify-manage-property {
   position: relative;
@@ -9050,7 +9111,7 @@ body.toggled #close-sidebar-wrapper {
     float: right;
     right: 15px;
     bottom: 90px;
-    z-index: 1000;
+    z-index: 99;
     width: 200px; }
     .pane-roomify-manage-property .manage-property-links .inner {
       margin: 0 auto;
@@ -9161,7 +9222,7 @@ body.toggled #close-sidebar-wrapper {
 
 .pane-roomify-property-flag-favorites-link {
   position: relative;
-  z-index: 999;
+  z-index: 98;
   top: 150px; }
   @media (max-width: 768px) {
     .pane-roomify-property-flag-favorites-link {
@@ -13295,48 +13356,11 @@ body.node-type-homepage {
     z-index: 3;
     color: white;
     border-bottom: 0; }
-  body.node-type-homepage header {
-    margin-bottom: 0;
-    z-index: 2;
-    background: transparent !important;
-    border-radius: 0;
-    border: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15); }
-    @media (max-width: 768px) {
-      body.node-type-homepage header {
-        background: rgba(0, 0, 0, 0.1); } }
-    body.node-type-homepage header .collasping,
-    body.node-type-homepage header .collapse.in {
-      width: 100%;
-      display: inline-block;
-      margin-bottom: 65px; }
-    body.node-type-homepage header .navbar-toggle:hover,
-    body.node-type-homepage header .navbar-toggle:focus {
-      background: transparent; }
-    body.node-type-homepage header a.name,
-    body.node-type-homepage header .navbar-nav > li > a {
-      font-weight: 400; }
-      @media (min-width: 768px) {
-        body.node-type-homepage header a.name,
-        body.node-type-homepage header .navbar-nav > li > a {
-          color: #FFFFFF !important; }
-          body.node-type-homepage header a.name:hover,
-          body.node-type-homepage header .navbar-nav > li > a:hover {
-            color: black !important; } }
-    body.node-type-homepage header .roomify-sidebar-menu-toggle svg {
-      fill: #FFFFFF; }
-      @media (max-width: 768px) {
-        body.node-type-homepage header .roomify-sidebar-menu-toggle svg {
-          fill: #484848; } }
-      body.node-type-homepage header .roomify-sidebar-menu-toggle svg:hover {
-        fill: black !important; }
   body.node-type-homepage .panel-content-top {
     position: relative; }
   body.node-type-homepage .main-container {
     padding-top: 0;
-    position: relative;
-    bottom: 75px;
-    padding-bottom: 75px; }
+    position: relative; }
   body.node-type-homepage .view-homepage-travel.view-display-id-panel_pane_1 .views-field-field-homepage-slideshow img {
     width: 100%;
     position: relative; }
@@ -13451,7 +13475,7 @@ body.node-type-homepage {
         backface-visibility: hidden; } }
     @media (max-width: 1440px) {
       body.node-type-homepage .pane-roomify-listing-availability-search-block-roomify-property-search {
-        max-width: 1100px; } }
+        max-width: 1128px; } }
     @media (max-width: 1200px) {
       body.node-type-homepage .pane-roomify-listing-availability-search-block-roomify-property-search {
         max-width: 900px; } }
@@ -14807,49 +14831,11 @@ body.page-single-property-listing {
     z-index: 3;
     color: white;
     border-bottom: 0; }
-  body.page-single-property-listing header {
-    margin-bottom: 0;
-    z-index: 2;
-    background: transparent !important;
-    border-radius: 0;
-    border: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15); }
-    @media (max-width: 768px) {
-      body.page-single-property-listing header {
-        background: rgba(0, 0, 0, 0.1); } }
-    body.page-single-property-listing header .collasping,
-    body.page-single-property-listing header .collapse.in {
-      width: 100%;
-      display: inline-block;
-      margin-bottom: 65px; }
-    body.page-single-property-listing header .navbar-toggle:hover,
-    body.page-single-property-listing header .navbar-toggle:focus {
-      background: transparent; }
-    body.page-single-property-listing header a.name,
-    body.page-single-property-listing header .navbar-nav > li > a {
-      font-weight: 400; }
-      @media (min-width: 768px) {
-        body.page-single-property-listing header a.name,
-        body.page-single-property-listing header .navbar-nav > li > a {
-          color: #FFFFFF !important; }
-          body.page-single-property-listing header a.name:hover,
-          body.page-single-property-listing header .navbar-nav > li > a:hover {
-            color: black !important; } }
-    body.page-single-property-listing header .roomify-sidebar-menu-toggle svg {
-      fill: #FFFFFF; }
-      @media (max-width: 768px) {
-        body.page-single-property-listing header .roomify-sidebar-menu-toggle svg {
-          fill: #484848; } }
-      body.page-single-property-listing header .roomify-sidebar-menu-toggle svg:hover {
-        fill: black !important; }
   body.page-single-property-listing .panel-content-top {
     position: relative; }
-  @media (min-width: 768px) {
-    body.page-single-property-listing .main-container {
-      padding-top: 0;
-      position: relative;
-      bottom: 75px;
-      padding-bottom: 75px; } }
+  body.page-single-property-listing .main-container {
+    padding-top: 0;
+    position: relative; }
   body.page-single-property-listing .pane-property-slideshow {
     border: none;
     min-height: inherit;

--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -11462,19 +11462,25 @@ ol.inline.commerce-checkout-progress {
           margin-left: 2%;
           text-align: left;
           padding-left: 0; }
+.page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup-content-wrapper,
+.page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup-content-wrapper {
+  border-radius: 4px; }
 .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup,
 .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup {
-  height: 250px; }
+  min-height: 250px; }
   .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content,
   .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .leaflet-popup-content {
-    max-width: 170px; }
+    max-width: 170px;
+    margin: 14px; }
   .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a,
   .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup a {
-    font-size: 18px; }
+    font-size: 16px;
+    color: #000000;
+    text-decoration: underline; }
   .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description,
   .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-short-description {
     margin: 5px 0;
-    font-size: 15px; }
+    font-size: 13px; }
   .page-activities-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image,
   .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image {
     display: inline-block;
@@ -11484,7 +11490,8 @@ ol.inline.commerce-checkout-progress {
     .page-availability-search .view-display-id-panel_pane_2 #leaflet-map .leaflet-popup .roomify-property-image img {
       width: 100% !important;
       border-radius: 2px;
-      min-width: 120px; }
+      min-width: 120px;
+      min-height: 120px; }
 
 #property-bat-activity-facets-availability .form-wrapper,
 #roomify-property-search-block-form .form-wrapper,

--- a/themes/roomify/roomify_travel/assets/sass/base/_mixins.scss
+++ b/themes/roomify/roomify_travel/assets/sass/base/_mixins.scss
@@ -136,7 +136,13 @@
     @include transition(.2s background-color ease-in-out);
 
     &::before {
-      @extend .glyphicon;
+      position: relative;
+      font-family: 'Glyphicons Halflings';
+      font-style: normal;
+      font-weight: normal;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
       top: auto;
       content: "\e005";
       color: white;

--- a/themes/roomify/roomify_travel/assets/sass/components/_messages.scss
+++ b/themes/roomify/roomify_travel/assets/sass/components/_messages.scss
@@ -1,7 +1,17 @@
 // Messages Styles
 
 .messages-container {
-  @extend .container;
+  @include container-fixed;
+
+  @media (min-width: $screen-sm-min) {
+    width: $container-sm;
+  }
+  @media (min-width: $screen-md-min) {
+    width: $container-md;
+  }
+  @media (min-width: $screen-lg-min) {
+    width: $container-lg;
+  }
 
   .messages-row {
     @include make-row();

--- a/themes/roomify/roomify_travel/assets/sass/pages/_area.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_area.scss
@@ -297,8 +297,26 @@
     text-align: right;
     margin: 25px 0;
     a {
-      @extend .btn;
-      @extend .btn-default;
+      display: inline-block;
+      margin-bottom: 0;
+      text-align: center;
+      vertical-align: middle;
+      touch-action: manipulation;
+      cursor: pointer;
+      background-image: none;
+      border: 1px solid transparent;
+      white-space: nowrap;
+      line-height: 1.42857;
+      border-radius: 4px;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      border-width: 0 1px 4px 1px;
+      font-size: 12px;
+      font-weight: 400;
+      text-transform: uppercase;
+      padding: 6px 10px 4px;
       @include button-variant(#FFFFFF, #127BA3, #158CBA);
     }
   }
@@ -306,9 +324,19 @@
     padding: 0 20px;
     margin-bottom: 35px;
   }
-  .panel_sl_content  {
-    @extend .container;
+  .panel_sl_content {
     float: none;
+    @include container-fixed;
+
+    @media (min-width: $screen-sm-min) {
+      width: $container-sm;
+    }
+    @media (min-width: $screen-md-min) {
+      width: $container-md;
+    }
+    @media (min-width: $screen-lg-min) {
+      width: $container-lg;
+    }
   }
   #property-bat-facets-availability {
     @media (max-width: $screen-md)  and (min-width: $screen-sm) {

--- a/themes/roomify/roomify_travel/assets/sass/pages/_availability-search.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_availability-search.scss
@@ -579,7 +579,7 @@
       border: 1px solid #D4D3D3;
     }
     .form-item-group-size,
-    .form-item-location  {
+    .form-item-location {
       @include make-xs-column(12);
       @include make-sm-column(12);
       @include make-md-column(3);
@@ -638,11 +638,11 @@
         margin-top: 32px;
       }
       .form-submit {
-        @extend .btn-danger;
         text-transform: capitalize;
         padding: 6px;
         font-size: 15px;
         width: 100%;
+        @include button-variant($btn-danger-color, $btn-danger-bg, $btn-danger-border);
       }
     }
     input, select, .form-control {

--- a/themes/roomify/roomify_travel/assets/sass/pages/_availability-search.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_availability-search.scss
@@ -505,17 +505,23 @@
   // MAP VIEW
   .view-display-id-panel_pane_2 {
     #leaflet-map {
+      .leaflet-popup-content-wrapper {
+        border-radius: 4px;
+      }
       .leaflet-popup {
-        height: 250px;
+        min-height: 250px;
         .leaflet-popup-content {
           max-width: 170px;
+          margin: 14px;
         }
         a {
-          font-size: 18px;
+          font-size: 16px;
+          color: #000000;
+          text-decoration: underline;
         }
         .roomify-property-short-description {
           margin: 5px 0;
-          font-size: 15px;
+          font-size: 13px;
         }
         .roomify-property-image {
           display: inline-block;
@@ -525,6 +531,7 @@
             width: 100% !important;
             border-radius: 2px;
             min-width: 120px;
+            min-height: 120px;
           }
         }
       }

--- a/themes/roomify/roomify_travel/assets/sass/pages/_blog.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_blog.scss
@@ -27,62 +27,62 @@
       }
       .pane-content {
         .views-row {/* Masonry blog posts */
-        .pane-blog-panel-pane-8,
-        .pane-blog-panel-pane-7,
-        .pane-blog-panel-pane-3 {
-          display: inline-block;
-          width: 100%;
-          .pane-term-name,
-          .pane-title {
-            text-align: center;
-            margin-top: 50px;
-          }
-          .view-display-id-panel_pane_8,
-          .view-display-id-panel_pane_7,
-          .view-display-id-panel_pane_3 {
-            .view-content {
-              margin: 0 auto;
+          .pane-blog-panel-pane-8,
+          .pane-blog-panel-pane-7,
+          .pane-blog-panel-pane-3 {
+            display: inline-block;
+            width: 100%;
+            .pane-term-name,
+            .pane-title {
+              text-align: center;
+              margin-top: 50px;
             }
-            .masonry-item {
-              border-radius: 5px;
-              width: 320px;
-              margin: 25px 0;
-              .views-field-field-featured-image {
-                img {
-                  border-radius: 5px 5px 0 0;
-                }
+            .view-display-id-panel_pane_8,
+            .view-display-id-panel_pane_7,
+            .view-display-id-panel_pane_3 {
+              .view-content {
+                margin: 0 auto;
               }
-              .views-field-body {
-                background-color: white;
-                color: #565656;
-                font-weight: 300;
-                padding: 0 10px 10px 10px;
-                border-radius: 0 0 5px 5px;
-                .field-content {
-                  padding-top: 10px;
-                  .views-more-link {
-                    display: block;
-                    margin-top: 10px;
+              .masonry-item {
+                border-radius: 5px;
+                width: 320px;
+                margin: 25px 0;
+                .views-field-field-featured-image {
+                  img {
+                    border-radius: 5px 5px 0 0;
                   }
                 }
-              }
-              .views-field-title-field { 
-                background: white;
-                padding: 10px;
-                border-bottom: 1px solid #E0E0E0;
-                a {
+                .views-field-body {
+                  background-color: white;
                   color: #565656;
-                  font-size: 16px;
-                  font-weight: 700;
+                  font-weight: 300;
+                  padding: 0 10px 10px 10px;
+                  border-radius: 0 0 5px 5px;
+                  .field-content {
+                    padding-top: 10px;
+                    .views-more-link {
+                      display: block;
+                      margin-top: 10px;
+                    }
+                  }
                 }
+                .views-field-title-field { 
+                  background: white;
+                  padding: 10px;
+                  border-bottom: 1px solid #E0E0E0;
+                  a {
+                    color: #565656;
+                    font-size: 16px;
+                    font-weight: 700;
+                  }
+                }
+                &:hover {
+                  opacity: .86;
+                }
+                @include transition(250ms opacity ease-out);
               }
-              &:hover {
-                opacity: .86;
-              }
-              @include transition(250ms opacity ease-out);
             }
           }
-        }
           .views-field-title-field {
             &:before {
               content: "•";
@@ -196,8 +196,6 @@
   }
   .pager-load-more a,
   .roomify-add-button {
-    @extend .btn;
-    @extend .btn-default;
     @include button-variant(#FFFFFF, #127BA3, #158CBA);
     border-left: 0;
     border-right: 0;
@@ -255,7 +253,6 @@
     }
   }
 }
-
 
 .node-type-blog {
   .panel_sl_content {
@@ -517,7 +514,7 @@
       .slick-slider {
         padding: 0 55px;
       }
-      .slick-slide  {
+      .slick-slide {
         padding: 15px;
         border: 1px solid #ececec;
         background: #f8f8f8;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_booking.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_booking.scss
@@ -67,7 +67,15 @@
           width: 100%;
           @include button-variant(#FFFFFF, #127BA3, #158CBA);
           &::before {
-            @extend .glyphicon;
+            position: relative;
+            top: 1px;
+            display: inline-block;
+            font-family: 'Glyphicons Halflings';
+            font-style: normal;
+            font-weight: normal;
+            line-height: 1;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
             content: "\e003";
             margin-right: 10px;
           }

--- a/themes/roomify/roomify_travel/assets/sass/pages/_checkout.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_checkout.scss
@@ -21,7 +21,6 @@
     position: relative;
     top: 15px;
     margin-bottom: 15px;
-    @extend .btn-warning;
   }
   .view-my-cart {
     table {
@@ -122,9 +121,6 @@
       padding-bottom: 15px;
       .checkout-continue {
         margin-right: 10px;
-        @extend .btn;
-        @extend .btn-default;
-        @extend .btn-success;
       }
       .button-operator {
         margin-right: 10px;
@@ -132,9 +128,6 @@
       .checkout-back,
       .checkout-cancel {
         margin-right: 10px;
-        @extend .btn;
-        @extend .btn-default;
-        @extend .btn-danger;
       }
     }
   }
@@ -252,7 +245,7 @@ ol.inline.commerce-checkout-progress {
         background: #f8f8f8;
       }
     }
-    .pane-data  {
+    .pane-data {
       background: #f8f8f8;
       border-bottom: 1px solid #d4d4d4;
       td,

--- a/themes/roomify/roomify_travel/assets/sass/pages/_contact.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_contact.scss
@@ -90,7 +90,7 @@
   .bootstrap-one-column {
     @include make-row();
   }
-  .panel_sl_content  {
+  .panel_sl_content {
     padding: 0;
   }
   .panel {

--- a/themes/roomify/roomify_travel/assets/sass/pages/_homepage.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_homepage.scss
@@ -201,13 +201,13 @@ body.node-type-homepage {
   background: #F8F8F8;
   padding-bottom: 20px;
   .views-row {
-    max-width: 380px;
+    max-width: 340px;
   }
   .view-featured-properties.view-display-id-panel_pane_3 {
     margin: 0 auto;
     max-width: 1200px;
     @media (max-width: $screen-sm-max) {
-      max-width: 380px;
+      max-width: 340px;
     }
   }
   .views-field-name {
@@ -225,10 +225,11 @@ body.node-type-homepage {
     margin: 10px 0;
     text-align: center;
   }
+  .unslick,
   .slide__content {
     margin: 0 auto;
     display: table;
-    max-width: 380px;
+    max-width: 340px;
     width: 100%;
     padding: 10px;
     background: white;
@@ -269,7 +270,7 @@ body.node-type-homepage {
     background-size: contain;
     right: 16px;
     @media (min-width: $screen-md) {
-      right: 25px;
+      right: 45px !important;
     }
   }
   .slick-prev.slick-arrow {
@@ -286,7 +287,7 @@ body.node-type-homepage {
     background-size: contain;
     left: 16px;
     @media (min-width: $screen-md) {
-      left: 25px;
+      left: 45px !important;
     }
   }
   .views-field-starting-price {

--- a/themes/roomify/roomify_travel/assets/sass/pages/_homepage.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_homepage.scss
@@ -10,54 +10,12 @@ body.node-type-homepage {
     color: white;
     border-bottom: 0;
   }
-  header {
-    margin-bottom: 0;
-    z-index: 2;
-    background: transparent !important;
-    border-radius: 0;
-    border: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-    @media (max-width: $screen-sm) {
-      background: rgba(0, 0, 0, 0.10);
-    }
-    .collasping,
-    .collapse.in {
-      width: 100%;
-      display: inline-block;
-      margin-bottom: 65px;
-    }
-    .navbar-toggle:hover,
-    .navbar-toggle:focus {
-      background: transparent;
-    }
-    a.name,
-    .navbar-nav > li > a {
-      font-weight: 400;
-      @media (min-width: $screen-sm) {
-        color: #FFFFFF !important;
-        &:hover {
-          color: black !important;
-        }
-      }
-    }
-    .roomify-sidebar-menu-toggle svg {
-      fill: #FFFFFF;
-      @media (max-width: $screen-sm) {
-        fill: #484848;
-      }
-      &:hover {
-        fill: black !important;
-      }
-    }
-  }
   .panel-content-top {
     position: relative;
   }
   .main-container {
     padding-top: 0;
     position: relative;
-    bottom: 75px;
-    padding-bottom: 75px;
   }
   // Slider
   .view-homepage-travel.view-display-id-panel_pane_1 {
@@ -185,7 +143,7 @@ body.node-type-homepage {
       backface-visibility: hidden;
     }
     @media (max-width: 1440px) {
-      max-width: 1100px;
+      max-width: 1128px;
     }
     @media (max-width: 1200px) {
       max-width: 900px;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_listing.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_listing.scss
@@ -268,7 +268,7 @@
     form {
       padding-top: 60px;
       position: relative;
-      border-top: 4px solid #158cba;
+      border-top: 3px solid #158cba;
       width: 100%;
     }
     label {
@@ -276,7 +276,7 @@
     }
     .listing-base-price {
       position: absolute;
-      top: 0;
+      top: -1px;
       right: 0;
       padding: 0 10px;
       background: #127ba3;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_listing.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_listing.scss
@@ -9,7 +9,7 @@
     float: right;
     right: 15px;
     bottom: 90px;
-    z-index: 1000;
+    z-index: 99;
     width: 200px;
     .inner {
       margin: 0 auto;
@@ -81,7 +81,7 @@
 
 .pane-roomify-property-flag-favorites-link {
   position: relative;
-  z-index: 999;
+  z-index: 98;
   top: 150px;
   @media (max-width: $screen-sm) {
     top: 40px;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_listing.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_listing.scss
@@ -539,6 +539,7 @@
   .pane-roomify-property-field-sp-highlight-image1-cap,
   .pane-roomify-property-field-sp-highlight-image2-cap,
   .pane-roomify-property-field-sp-highlight-image3-cap {
+    font-weight: 500;
     img {
       margin: 60px auto 10px auto;
       border: 1px solid #ececec;
@@ -610,12 +611,12 @@
               }
               a {
                 color: #127ba3;
+                font-size: 22px;
                 text-decoration: none;
               }
               img {
                 max-width: 140px;
                 border-radius: 2px;
-                border: 1px solid #ECECEC;
                 margin-left: 25px;
                 margin-top: 15px;
               }
@@ -626,7 +627,7 @@
               font-style: italic;
               .type-description {
                 @media (min-width: $screen-md) {
-                  margin-top: 45px;
+                  margin-top: 65px;
                 }
                 font-style: normal;
                 p {
@@ -677,10 +678,9 @@
                 height: 25px;
               }
               a {
-                font-size: 15px;
-                width: 120px;
+                font-size: 12px;
+                width: 125px;
                 text-align: center;
-                color: white;
                 @include button-variant(#FFFFFF, #127BA3, #158CBA);
               }
               .info {
@@ -692,20 +692,25 @@
             }
             .footable-row-detail-inner {
               margin: 10px 0;
+              padding: 30px;
+              display: block;
               border-radius: 2px;
               border: 1px solid #ececec;
-              background: #f8f8f8;
+              background: rgb(250, 250, 250);
+              .footable-row-detail-value {
+                line-height: 2em;
+              }
               .footable-row-detail-row {
                 margin: 8px 2%;
                 display: inline-block;
                 width: 100%;
                 &:first-child {
-                  width: 100%;
-                  margin-top: 25px;
                   margin-bottom: 10px;
-                  padding: 0 10px;
                   font-weight: 400;
                   font-size: 15px;
+                  .footable-row-detail-name {
+                    padding-right: 0;
+                  }
                   .type-description {
                     font-style: normal;
                     p {

--- a/themes/roomify/roomify_travel/assets/sass/pages/_single-property.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_single-property.scss
@@ -11,58 +11,13 @@ body.page-single-property-listing {
     color: white;
     border-bottom: 0;
   }
-  header {
-    margin-bottom: 0;
-    z-index: 2;
-    background: transparent !important;
-    border-radius: 0;
-    border: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-    @media (max-width: $screen-sm) {
-      background: rgba(0, 0, 0, 0.10);
-    }
-    .collasping,
-    .collapse.in {
-      width: 100%;
-      display: inline-block;
-      margin-bottom: 65px;
-    }
-    .navbar-toggle:hover,
-    .navbar-toggle:focus {
-      background: transparent;
-    }
-    a.name,
-    .navbar-nav > li > a {
-      font-weight: 400;
-      @media (min-width: $screen-sm) {
-        color: #FFFFFF !important;
-        &:hover {
-          color: black !important;
-        }
-      }
-    }
-    .roomify-sidebar-menu-toggle svg {
-      fill: #FFFFFF;
-      @media (max-width: $screen-sm) {
-        fill: #484848;
-      }
-      &:hover {
-        fill: black !important;
-      }
-    }
-  }
   .panel-content-top {
     position: relative;
   }
   .main-container {
-  	@media (min-width: $screen-sm) {
-	    padding-top: 0;
-	    position: relative;
-	    bottom: 75px;
-	    padding-bottom: 75px;
-	  }
+    padding-top: 0;
+    position: relative;
   }
-
   .pane-property-slideshow {
 	  border: none;
 	  min-height: inherit;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_single-property.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_single-property.scss
@@ -300,6 +300,9 @@ body.page-single-property-listing {
     font-size: 26px;
     text-align: center;
     margin: 50px 0;
+    @media (max-width: $screen-xs) {
+      margin-bottom: 0;
+    }
 	}
 	.panel-content-wrapper,
 	.panel-content-bottom {
@@ -317,9 +320,9 @@ body.page-single-property-listing {
         li.ui-state-default {
           border-width: 1px;
           border-bottom: 0;
-          float: right;
+          float: left;
           &:first-child {
-            margin-right: 0;
+            //margin-right: 0;
           }
         }
       }
@@ -397,26 +400,16 @@ body.page-single-property-listing {
       }
     }
   }
-  .casa-property-description {
-    display: inline-block;
-    width: 100%;
-    padding: 30px;
-    background: white;
-    border-radius: 2px;
-    border: 1px solid #ececec;
-    margin-top: 52px;
-    margin-bottom: 50px;
-  }
   /* PROPERTY TYPES */
   .view-property-travel {
     display: inline-block;
     width: 100%;
-    padding: 30px;
-    background: white;
-    border-radius: 2px;
-    border: 1px solid #ececec;
-    margin-top: 52px;
-    margin-bottom: 50px;
+    padding: 18px;
+    margin-top: 40px;
+    margin-bottom: 40px;
+    @media (max-width: $screen-xs) {
+      padding: 0;
+    }
     .views-row {
       display: inline-block;
       width: 100%;
@@ -432,14 +425,23 @@ body.page-single-property-listing {
           font-size: 20px;
           margin-bottom: 20px;
           display: inline-block;
-          font-weight: 400;
+          color: initial;
+          @media (min-width: $screen-md) {
+            font-size: 24px;
+          }
         }
       }
+       .views-field-field-st-description {
+        font-size: 16px;
+       }
       .views-field-field-st-gallery {
         display: inline-block;
         float: left;
         margin-right: 20px;
-        max-width: 250px;
+        max-width: 360px;
+        @media (max-width: $screen-xs) {
+          margin-bottom: 15px;
+        }
         img {
           border-radius: 2px;
         }
@@ -451,6 +453,7 @@ body.page-single-property-listing {
         a.btn {
           @include make-xs-column(4);
           float: right;
+          max-width: 200px;
         }
         .info {
           @include make-xs-column(8);

--- a/themes/roomify/roomify_travel/assets/sass/pages/_single-property.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_single-property.scss
@@ -1,4 +1,3 @@
-
 body.page-single-property-listing {
   background: #F8F8F8;
   strong {
@@ -229,11 +228,11 @@ body.page-single-property-listing {
 	      @include make-xs-column(12);
 	      @include make-sm-column(3.5);
 	      .form-submit {
-	        @extend .btn-danger;
 	        text-transform: capitalize;
 	        padding: 6px;
 	        font-size: 14px;
 	        width: 100%;
+          @include button-variant($btn-danger-color, $btn-danger-bg, $btn-danger-border);
 	      }
 	    }
       .listing-availability-search-submit {
@@ -262,13 +261,13 @@ body.page-single-property-listing {
 	      height: 35px;
 	      font-size: 15px;
 	      &.form-text::-webkit-input-placeholder {
-	        color: #353535;
+	        color: #c9c9c9;
 	      }
 	      &.form-text::-moz-placeholder {
-	        color: #353535;
+	        color: #c9c9c9;
 	      }
 	      &.form-text:-moz-placeholder {
-	        color: #353535;
+	        color: #c9c9c9;
 	      }
     	}
     }
@@ -306,7 +305,17 @@ body.page-single-property-listing {
 	}
 	.panel-content-wrapper,
 	.panel-content-bottom {
-		@extend .container;
+		@include container-fixed;
+
+    @media (min-width: $screen-sm-min) {
+      width: $container-sm;
+    }
+    @media (min-width: $screen-md-min) {
+      width: $container-md;
+    }
+    @media (min-width: $screen-lg-min) {
+      width: $container-lg;
+    }
 	}
 	.panel-content-bottom {
 		margin-bottom: 70px;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_type.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_type.scss
@@ -249,6 +249,17 @@
             }
           }
         }
+        .form-item-group-size {
+          width: 100%;
+          margin-bottom: 25px;
+          select {
+            width: 100%;
+            border-radius: 2px;
+            -webkit-border-radius: 2px;
+            color: #353535;
+            font-size: 15px;
+          }
+        }
         .bat-type-availability-search-submit {
           button {
             @extend .btn;

--- a/themes/roomify/roomify_travel/assets/sass/pages/_type.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_type.scss
@@ -262,9 +262,6 @@
         }
         .bat-type-availability-search-submit {
           button {
-            @extend .btn;
-            @extend .btn-default;
-            @extend .btn-danger;
             width: 100%;
           }
         }

--- a/themes/roomify/roomify_travel/assets/sass/regions/_footer.scss
+++ b/themes/roomify/roomify_travel/assets/sass/regions/_footer.scss
@@ -7,7 +7,7 @@
   text-align: center;
   color: #f8f8f8;
   .footer-social-icons {
-    @extend .clearfix;
+    @include clearfix;
     margin: 0 auto 20px auto;
     max-width: 260px;
 

--- a/themes/roomify/roomify_travel/assets/sass/regions/_header.scss
+++ b/themes/roomify/roomify_travel/assets/sass/regions/_header.scss
@@ -1,113 +1,82 @@
-.roomify-sidebar-link { //Sidebar Link
-  margin-left: 20px;
-  width: 30px;
-  height: 30px;
-  padding: 0;
-  a {
-    width: 30px;
-    height: 30px;
-    display: inline-block;
-    @media (min-width: $screen-sm) {
-      position: relative;
-      top: 8px;
-    }
-  }
-  @include breakpoint(xs) {
-    margin: 0 0 30px 0;
-  }
-}
-
-body header.roomify-header .navbar-collapse nav ul.navbar-nav > li > a {
-  color: #484848;
-}
-body header.roomify-header .navbar-collapse nav ul.navbar-nav > li > a:hover {
-  color: #000000;
-}
-
-body header.roomify-header {
-  min-height: 70px;
-  background: #ffffff;
+header.roomify-header {
+  margin-bottom: 0;
   border-radius: 0;
-  border-right: 0;
   border-left: 0;
-  .navbar-collapse nav ul.nav li a {
-    @media (min-width: $screen-sm) and (max-width: $screen-md) {
-      font-size: 12px;
-    }
-  }
-  .navbar nav ul.navbar-nav > li > a:hover {
-    color: #333333;
-  }
-  .container {
+  border-right: 0;
+  .container:first-child {
     @media (min-width: $screen-sm) {
-      padding: 0;
+      padding-left: 0;;
+      padding-right: 0;
     }
   }
-  a.logo {
-    margin-top: 0;
-    margin-bottom: 0;
-    img {
-      height: 66px;
-      margin: 2px 0;
-    }
+  .navbar-header {
+    width: 100%;
+    display: table;
+    margin: 0 auto;
+    min-height: 60px;
   }
-  a.name {
-    font-size: 22px;
-    margin-top: 10px;
-  }
-  .navbar-collapse.collapse {
-    float: right;
-    margin-top: 15px;
-    &.collasping,
-    &.in {
-      float: none;
+  // MAIN MENU
+  .roomify-site-menu {
+    position: relative;
+    .inner {
+      padding-left: 0;
     }
-  }
-  // Mobile Button
-  .navbar-toggle {
-    position: absolute;
-    top: 20px;
-    right: 30px;
-    float: none;
-    margin-right: 0;
-    padding: 0;
-    margin: 0;
-    background-color: transparent;
-    background-image: none;
-    border: 0;
-    border-radius: 0;
-    z-index: 9;
-    .icon-bar {
-      height: 3px;
-    }
-    &:hover,
-    &:focus {
+    .navbar-toggle {
+      display: block;
+      border: 0;
       background: transparent;
+      top: 3px;
+      position: relative;
+      float: left;
+      @media (max-width: $screen-xs-max) {
+        top: 0;
+      }
     }
   }
-}
 
-.navbar-nav > li > .dropdown-menu {
-  margin-top: 6px;
-  background: white;
-  min-width: 220px;
-  border: 2px solid #e7e7e7;
-  padding: 0;
-  li {
-    border-bottom: 1px solid #f8f8f8;
-    :last-child {
-      border: none;
+  // NAME & LOGO
+  .roomify-site-name {
+    margin-top: 2px;
+    a.name {
+      text-align: center;
+      display: inline-block;
+      font-size: 22px;
+      margin-top: 5px;
+      width: 100%;
     }
-    a {
-      font-size: 14px;
-      padding: 10px;
-      background: white;
-      color: #333333;
-      &:hover,
-      &:focus {
-        background: #F8F8F8;
-        color: #333333;
+    a.logo {
+      display: table;
+      margin: 8px auto;
+      max-height: 60px;
+    }
+  }
+  // USER MENU
+  .roomify-user-menu  {
+    position: relative;
+    .roomify-sidebar-link { //Sidebar Link
+      padding: 0;
+      a {
+        width: 30px;
+        height: 30px;
+        display: inline-block;
+        width: 100%;
+        position: relative;
+        @media (min-width: $screen-sm) {
+          position: relative;
+        }
+        svg {
+          height: 28px;
+          width: 28px;
+          right: 0;
+          position: absolute;
+        }
       }
+      @include breakpoint(xs) {
+        margin: 0 0 30px 0;
+      }
+    }
+    .inner {
+      padding-right: 0;
     }
   }
 }

--- a/themes/roomify/roomify_travel/assets/sass/regions/_overlay-menu.scss
+++ b/themes/roomify/roomify_travel/assets/sass/regions/_overlay-menu.scss
@@ -1,0 +1,84 @@
+/* The Overlay (background) */
+.roomify-overlay {
+  /* Height & width depends on how you want to reveal the overlay (see JS below) */    
+  height: 100%;
+  width: 100%;
+  position: fixed; /* Stay in place */
+  z-index: 100; /* Sit on top */
+  left: 0;
+  top: 0;
+  display: none;
+  background-color: rgb(0,0,0); /* Black fallback color */
+  background-color: rgba(0,0,0, 0.92); /* Black w/opacity */
+  overflow-x: hidden; /* Disable horizontal scroll */
+  opacity: 0;
+  @include transition(200ms opacity ease-in-out);
+  .overlay-content {
+    position: relative;
+    top: 20%; /* 25% from the top */
+    width: 100%; /* 100% width */
+    text-align: center; /* Centered text/links */
+    margin-top: 30px; /* 30px top margin to avoid conflict with the close button on smaller screens */
+    a {
+      padding: 15px 8px;
+      text-decoration: none;
+      font-size: 36px;
+      color: #818181;
+      display: block; /* Display block instead of inline */
+      transition: 0.3s; /* Transition effects on hover (color) */
+      &:hover,
+      &:focus {
+        color: #f1f1f1;
+      }
+    }
+    .menu {
+      li {
+        &:hover,
+        &:focus {
+          background: transparent;
+        }
+        .dropdown-menu {
+          max-width: 360px;
+          margin: 0 auto;
+          left: 0;
+          right: 0;
+          border-radius: 0;
+          background: rgba(0, 0, 0, 0.90);
+          border: 0;
+          li a {
+            font-size: 22px;
+            text-align: center;
+            padding: 8px;
+          }
+        }
+        .active > a,
+        .active > a:hover,
+        .active > a:focus {
+          background-color: transparent;
+        }
+        a {
+          &:hover,
+          &:focus {
+            background: transparent;
+          }
+        }
+      }
+    }
+  }
+  .closebtn {
+    position: absolute;
+    top: 20px;
+    right: 45px;
+    font-size: 60px;
+  }
+  @media screen and (max-height: 450px) {
+    a {
+      font-size: 20px;
+    }
+    .closebtn {
+      font-size: 40px;
+      top: 15px;
+      right: 35px;
+    }
+  }
+}

--- a/themes/roomify/roomify_travel/assets/sass/regions/_overlay-menu.scss
+++ b/themes/roomify/roomify_travel/assets/sass/regions/_overlay-menu.scss
@@ -4,7 +4,7 @@
   height: 100%;
   width: 100%;
   position: fixed; /* Stay in place */
-  z-index: 100; /* Sit on top */
+  z-index: 1001; /* Sit on top */
   left: 0;
   top: 0;
   display: none;

--- a/themes/roomify/roomify_travel/assets/sass/regions/_sidebar.scss
+++ b/themes/roomify/roomify_travel/assets/sass/regions/_sidebar.scss
@@ -94,7 +94,7 @@ body {
           }
         }
         .sidebar-profile-message {
-          @extend .h3;
+          @include h3();
           text-align: center;
           color: white;
           margin-top: 0px;
@@ -175,10 +175,11 @@ body {
           }
         }
       }
-      .form-actions  {
+      .form-actions {
         button {
+          background-color: $btn-success-bg;
+          border-color: $btn-success-border;
           width: 100%;
-          @extend .btn-success;
           font-size: 16px;
           span {
             margin-right: 6px;

--- a/themes/roomify/roomify_travel/assets/sass/regions/_sidebar.scss
+++ b/themes/roomify/roomify_travel/assets/sass/regions/_sidebar.scss
@@ -1,7 +1,6 @@
-
 body {
   padding-right: 0;
-  @include transition(70ms all linear);
+  @include transition(60ms all linear);
   #sidebar-wrapper {
     z-index: 1000;
     position: fixed;
@@ -12,13 +11,15 @@ body {
     overflow-y: auto;
     background: #000;
     overflow-x: hidden;
-    @include transition(70ms all linear);
-    @include transition(2ms width linear);
+    @include transition(60ms all linear);
     .close-sidebar {
       border-bottom: 0;
       margin-bottom: 0;
       width: 100%;
       padding-bottom: 10px;
+      &:after {
+        display: none;
+      }
     }
     #close-sidebar-icon {
       background: url('../images/close.png') center center no-repeat;
@@ -45,11 +46,24 @@ body {
     .panel-pane {
       display: inline-block;
       width: 100%;
-      margin-bottom: 30px;
-      border-bottom: 1px solid #03A9F4;
+      margin-bottom: 10px;
       padding-bottom: 30px;
+      min-width: 320px;
+      &:after {
+        content: "";
+        width: 100px;
+        text-align: center;
+        height: 3px;
+        border-radius: 50px;
+        display: table;
+        margin: 0 auto;
+        background: #696969;
+        margin-top: 35px;
+      }
       &:last-child {
-        border-bottom: none;
+        &:after {
+          display: none;
+        }
       }
       .pane-title {
         border-bottom: 0;
@@ -57,12 +71,12 @@ body {
         width: 100%;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
         font-size: 22px;
-        text-align: center;
       }
     }
     .pane-roomify-sidebar-user-menu {
+
       .pane-title {
         margin-bottom: 5px;
         font-size: 22px;
@@ -184,7 +198,7 @@ body {
         display: none;
       }
       .glyphicon {
-        font-size: 20px;
+        font-size: 18px;
         margin-right: 4px;
         color: #03A9F4;
         position: relative;
@@ -228,14 +242,15 @@ body {
         font-weight: 400;
         border-bottom: 0;
         font-size: 22px;
-        text-align: center;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
+          top: 2px;
+          right: 4px;
         }
         a {
           color: white;
@@ -292,12 +307,13 @@ body {
         color: white;
         font-weight: 400;
         font-size: 22px;
-        text-align: center;
+        padding: 5px 15px;
+        text-align: left;
         border-bottom: 0;
         width: 100%;
         .glyphicon {
           display: inline-block;
-          font-size: 20px;
+          font-size: 18px;
           margin-right: 6px;
           z-index: 99;
           color: #03A9F4;
@@ -343,12 +359,12 @@ body {
         margin-bottom: 5px;
         color: white;
         font-weight: 400;
-        padding: 5px 10px;
+        padding: 5px 15px;
+        text-align: left;
         font-size: 22px;
         float: left;
         border: 0;
         color: white;
-        text-align: center;
       }
       .view-my-stays {
         .views-row {
@@ -384,8 +400,6 @@ body {
       }
     }
   }
-
-
   &.toggled {
     padding-right: 350px;
     margin-left: -350px;
@@ -408,6 +422,11 @@ body {
       margin-left: -300px;
       #sidebar-wrapper {
         width: 300px;
+      }
+      .sidebar-nav {
+        .panel-pane {
+          min-width: 280px;
+        }
       }
     }
   }
@@ -436,7 +455,6 @@ body.toggled {
     background: rgba(0, 0, 0, 0.35);
     height: 100%;
     cursor: pointer;
-    @include transition(70ms all linear);
-    @include transition(2ms width linear);
+    @include transition(60ms all linear);
   }
 }

--- a/themes/roomify/roomify_travel/assets/sass/style.scss
+++ b/themes/roomify/roomify_travel/assets/sass/style.scss
@@ -36,7 +36,6 @@
 @import "components/fieldset";
 @import "components/hoverffect";
 
-
 // Region Styles
 @import "regions/body";
 @import "regions/header";

--- a/themes/roomify/roomify_travel/assets/sass/style.scss
+++ b/themes/roomify/roomify_travel/assets/sass/style.scss
@@ -43,6 +43,7 @@
 @import "regions/content";
 @import "regions/footer";
 @import "regions/sidebar";
+@import "regions/overlay-menu";
 
 // Pages
 @import "pages/listing";

--- a/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
+++ b/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
@@ -26,7 +26,6 @@ Drupal.behaviors.roomifyTravelScripts = {
       $('body').toggleClass('toggled');
     });
 
-
     // Top level menu links should be clickable.
     $('.navbar .dropdown > a').click(function(){
       location.href = this.href;
@@ -50,6 +49,20 @@ Drupal.behaviors.roomifyTravelScripts = {
         $(this).closest('.slide__caption').hide();
       }
     });
+
+    // Add an animation based on opacity.
+    $('#roomify-main-menu-overlay .closebtn').once().click(function(e) {
+      $('#roomify-main-menu-overlay').css('opacity', '0');
+    });
+    $('.roomify-site-menu .navbar-toggle').once().click(function(e) {
+      $('#roomify-main-menu-overlay').css('opacity', '1');
+    });
+
+    // Place hamburger and user icons in the center of the header.
+    var headerHeight = $('.roomify-header').outerHeight();
+    var hamburgerHeight = $('.roomify-header .roomify-site-menu .inner').outerHeight();
+    $('.roomify-header .roomify-site-menu').css('top', (headerHeight - hamburgerHeight)/2 );
+    $('.roomify-header .roomify-user-menu').css('top', (headerHeight - 28)/2);
   }
 };
 

--- a/themes/roomify/roomify_travel/color/color.css
+++ b/themes/roomify/roomify_travel/color/color.css
@@ -1,23 +1,12 @@
 /* HEADER */
 body header.roomify-header { background-color: #ffffff; }
-body.node-type-homepage header.roomify-header {background:  transparent;}
-/* WIDE LOCANDA HOMEPAGE */
-@media screen and (max-width: 767px) {
-  body.page-locanda-listing header {
-    background-color: #ffffff;
-  }
-}
-
-body.page-locanda-listing header {
-	background-color: #ffffff;
-}
+body header.roomify-header { border-color: #e7e7e7; }
 
 /* FOOTER */
 body footer.roomify-footer { background-color: #15262f; }
 
 
 /* SITE NAME - LINKS HEADER/FOOTER */
-body header.roomify-header .navbar-collapse nav ul.navbar-nav > li > a,
 body header.roomify-header a.name,
 body footer.roomify-footer a { color: #484848; }
 
@@ -32,29 +21,19 @@ body header.roomify-header .navbar-toggle .icon-bar {
   fill: #484848;
 }
 
-body header.roomify-header .navbar-collapse nav ul.navbar-nav li .submenu-button:after,
-body header.roomify-header .navbar-collapse nav ul.navbar-nav li .submenu-button:before {
-  background-color: #484848;
-}
-
 
 /* ON HOVER LINKS HEADER/FOOTER */
-body header.roomify-header .navbar-collapse nav ul.navbar-nav > li > a:hover,
 body header.roomify-header a.name:hover,
 body footer.roomify-footer a:hover { color: #000000; }
 
 body footer.roomify-footer .rsp-social-icon { background: #ffffff; }
 
+.roomify-footer svg:hover,
 /* USER ICON */
 .roomify-sidebar-menu-toggle svg:hover { fill: #000000; }
 /* HAMBURGER MENU */
 body header.roomify-header .navbar-toggle:hover .icon-bar {
   background: #000000;
-}
-
-body header.roomify-header .navbar-collapse  nav ul.navbar-nav li .dropdown-menu li a:hover {
-	color: #ffffff;
-	background: #15262f;
 }
 
 /* TEXT HEADER/FOOTER */

--- a/themes/roomify/roomify_travel/color/color.inc
+++ b/themes/roomify/roomify_travel/color/color.inc
@@ -10,6 +10,7 @@ $info = array();
 // Define the possible replaceable items and their labels.
 $info['fields'] = array(
   'header' => t('Header'),
+  'header-border' => t('Header Border'),
   'footer' => t('Footer'),
   'links' => t('Header/Footer Links'),
   'hoverlinks' => t('Header/Footer Hover Menu Links'),
@@ -21,6 +22,7 @@ $info['schemes']['default'] = array(
   'title' => t('Default'),
   'colors' => array(
     'header' => '#ffffff',
+    'header-border' => '#e7e7e7',
     'footer' => '#15262f',
     'links' => '#484848',
     'hoverlinks' => '#000000',

--- a/themes/roomify/roomify_travel/color/preview.css
+++ b/themes/roomify/roomify_travel/color/preview.css
@@ -5,13 +5,17 @@
   display: inline-block;
   padding: 8px 16px;
 }
-
+#preview #header {
+  border-bottom: 4px solid #e7e7e7;
+  border-color: #e7e7e7;
+}
 #preview .logo {
   height: 100%;
-  width: 25%;
+  width: 60%;
   display: inline-block;
   float: left;
   text-align: center;
+  position: relative;
 }
 #preview .logo img {
   max-height: 100%;
@@ -19,37 +23,29 @@
 
 #preview .main-menu {
   float: left;
-  width: 70%;
-  text-align: right;
+  width: 20%;
+  margin-top: 10px;
 }
 
-#preview .main-menu .menu {
-  float: right;
-}
-#preview .menu li {
-  display: inline-block;
-  float: left;
-  list-style: none;
-  padding: 15px;
-}
-#preview .menu li a {
-  color: #7C7C7C;
-  font-weight: 600;
-}
 
+#preview .main-menu svg {
+  fill: #484848;
+}
 
 #preview .roomify-sidebar-link {
-  margin-left: 20px;
-  width: 30px;
   height: 30px;
-  padding: 0;
+  display: inline-block;
+  width: 20%;
+  position: relative;
+  margin-top: 10px;
 }
 #preview .roomify-sidebar-link a {
   width: 30px;
   height: 30px;
   display: inline-block;
-  position: relative;
-  top: 8px;
+  position: absolute;
+  top: 0px;
+  right: 0;
 }
 
 

--- a/themes/roomify/roomify_travel/color/preview.js
+++ b/themes/roomify/roomify_travel/color/preview.js
@@ -15,13 +15,14 @@
       // header
       $('#preview header', form).css('background-color', $('#palette input[name="palette[header]"]', form).val());
     
+      $('#preview header', form).css('border-color', $('#palette input[name="palette[header-border]"]', form).val());
       // Menu Links
-      $('#preview header li a', form).css('color', $('#palette input[name="palette[links]"]', form).val());
+      $('#preview header .main-menu svg', form).css('fill', $('#palette input[name="palette[links]"]', form).val());
 
-      $("#preview header li a").hover(function() {
-        $(this, form).css("color", $('#palette input[name="palette[hoverlinks]"]', form).val());
+      $("#preview header .main-menu svg").hover(function() {
+        $(this, form).css("fill", $('#palette input[name="palette[hoverlinks]"]', form).val());
       },function(){
-        $(this, form).css("color", $('#palette input[name="palette[links]"]', form).val());
+        $(this, form).css("fill", $('#palette input[name="palette[links]"]', form).val());
       });
 
       // User Icon

--- a/themes/roomify/roomify_travel/color/preview.php
+++ b/themes/roomify/roomify_travel/color/preview.php
@@ -1,7 +1,12 @@
 <div id="preview">
   <!-- Header. -->  
   <header id="header">
-
+    <span class="main-menu">
+      <a class="roomify-main-menu-hamburger" href="#menu-toggle">
+        <!-- PRINT SVG USER ICON -->
+        <svg height="32px" id="Layer_1" style="enable-background:new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="32px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M4,10h24c1.104,0,2-0.896,2-2s-0.896-2-2-2H4C2.896,6,2,6.896,2,8S2.896,10,4,10z M28,14H4c-1.104,0-2,0.896-2,2  s0.896,2,2,2h24c1.104,0,2-0.896,2-2S29.104,14,28,14z M28,22H4c-1.104,0-2,0.896-2,2s0.896,2,2,2h24c1.104,0,2-0.896,2-2  S29.104,22,28,22z"/></svg>
+      </a>
+    </span>
     <div class="logo">
       <img class="img-responsive" src="<?php
         $theme = variable_get('theme_default', 'bartik');
@@ -12,22 +17,6 @@
           print file_create_url(theme_get_setting('logo_path', $theme));
         }
       ?>">
-    </div>
-    <div class="main-menu">
-      <ul class="menu nav navbar-nav">
-        <li>
-          <a href="/">Activities </a>
-        </li>
-        <li>
-          <a href="/">Blog</a>
-        </li>
-        <li>
-          <a href="/">Location</a>
-        </li>
-        <li>
-          <a href="/">Contact Us</a>
-        </li>
-      </ul>
     </div>
     <span class="roomify-sidebar-link">
       <a class="roomify-sidebar-menu-toggle" href="#menu-toggle">

--- a/themes/roomify/roomify_travel/template.php
+++ b/themes/roomify/roomify_travel/template.php
@@ -357,9 +357,7 @@ function roomify_travel_preprocess_page(&$variables) {
   // Areas custom template.
   if(arg(0) == 'taxonomy' && arg(1) == 'term') {
     $tid = (int)arg(2);
-    //dpm($tid);
     $term = taxonomy_term_load($tid);
-    //dpm($term);
 
     if($term->vocabulary_machine_name == 'location') {
       $variables['theme_hook_suggestions'][] = 'page__taxonomy__location';

--- a/themes/roomify/roomify_travel/templates/page--homepage.tpl.php
+++ b/themes/roomify/roomify_travel/templates/page--homepage.tpl.php
@@ -74,7 +74,21 @@
  */
 ?>
 
-<?php $directory = drupal_get_path('theme', 'roomify_travel');;?>
+<?php $directory = drupal_get_path('theme', 'roomify_travel'); ?>
+<!-- The overlay Menu -->
+<div id="roomify-main-menu-overlay" class="roomify-overlay">
+  <!-- Button to close the overlay navigation -->
+  <a href="javascript:void(0)" class="closebtn" onclick="document.getElementById('roomify-main-menu-overlay').style.display = 'none';">&times;</a>
+
+  <!-- Overlay content -->
+  <div class="overlay-content">
+    <?php 
+      $main_menu = menu_tree_output(menu_tree_all_data('main-menu', NULL, 2));
+      print drupal_render($main_menu);
+    ?>
+  </div>
+</div>
+
 <!-- Sidebar Content-->
 <div id="sidebar-wrapper">
   <div class="sidebar-nav">
@@ -97,55 +111,44 @@
   <header id="navbar" role="banner" class="roomify-header <?php print $navbar_classes; ?>">
     <div class="container">
       <div class="navbar-header">
-        <?php if ($logo): ?>
-          <a class="logo navbar-btn pull-left" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
-            <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
-          </a>
-        <?php endif; ?>
+        <div class="roomify-site-menu">
+          <div class="inner col-xs-1">
+            <button type="button" class="navbar-toggle" onclick='document.getElementById("roomify-main-menu-overlay").style.display = "block";'>
+              <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+          </div>
+        </div>
 
-        <?php if (!empty($site_name)): ?>
-          <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
-        <?php endif; ?>
-
-        <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-          <!-- Sidebar menu button -->
-          <button type="button" class="roomify-sidebar-user-icon navbar-toggle sidebar-menu-toggle roomify-sidebar-menu-toggle" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-          </button>
-
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-        <?php endif; ?>
-      </div>
-
-      <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-        <div class="navbar-collapse collapse">
-          <nav role="navigation">
-            <?php if (!empty($primary_nav)): ?>
-              <?php print render($primary_nav); ?>
-            <?php endif; ?>
-            <?php if (!empty($secondary_nav)): ?>
-              <?php print render($secondary_nav); ?>
+        <div class="roomify-site-name">
+          <div class="inner col-xs-10">
+            <?php if ($logo): ?>
+              <a class="logo" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
+                <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
+              </a>
             <?php endif; ?>
 
-            <!-- Link to open sidebar menu -->
+            <?php if (!empty($site_name)): ?>
+              <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
+            <?php endif; ?>
+          </div>
+        </div>
+
+        <div class="roomify-user-menu">
+          <div class="inner col-xs-1">
+          <!-- Link to open sidebar menu -->
             <span class="roomify-sidebar-link">
               <a class="roomify-sidebar-menu-toggle" href="#menu-toggle">
                 <!-- PRINT SVG USER ICON -->
                 <?php print(file_get_contents($directory . '/assets/images/user.svg')); ?>
               </a>
             </span>
-
-            <?php if (!empty($page['navigation'])): ?>
-              <?php print render($page['navigation']); ?>
-            <?php endif; ?>
-          </nav>
+          </div>
         </div>
-      <?php endif; ?>
+
+      </div>
     </div>
   </header>
 

--- a/themes/roomify/roomify_travel/templates/page--locanda-listing.tpl.php
+++ b/themes/roomify/roomify_travel/templates/page--locanda-listing.tpl.php
@@ -74,7 +74,21 @@
  */
 ?>
 
-<?php $directory = drupal_get_path('theme', 'roomify_travel');;?>
+<?php $directory = drupal_get_path('theme', 'roomify_travel'); ?>
+<!-- The overlay Menu -->
+<div id="roomify-main-menu-overlay" class="roomify-overlay">
+  <!-- Button to close the overlay navigation -->
+  <a href="javascript:void(0)" class="closebtn" onclick="document.getElementById('roomify-main-menu-overlay').style.display = 'none';">&times;</a>
+
+  <!-- Overlay content -->
+  <div class="overlay-content">
+    <?php 
+      $main_menu = menu_tree_output(menu_tree_all_data('main-menu', NULL, 2));
+      print drupal_render($main_menu);
+    ?>
+  </div>
+</div>
+
 <!-- Sidebar Content-->
 <div id="sidebar-wrapper">
   <div class="sidebar-nav">
@@ -97,55 +111,44 @@
   <header id="navbar" role="banner" class="roomify-header <?php print $navbar_classes; ?>">
     <div class="container">
       <div class="navbar-header">
-        <?php if ($logo): ?>
-          <a class="logo navbar-btn pull-left" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
-            <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
-          </a>
-        <?php endif; ?>
+        <div class="roomify-site-menu">
+          <div class="inner col-xs-1">
+            <button type="button" class="navbar-toggle" onclick='document.getElementById("roomify-main-menu-overlay").style.display = "block";'>
+              <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+          </div>
+        </div>
 
-        <?php if (!empty($site_name)): ?>
-          <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
-        <?php endif; ?>
-
-        <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-          <!-- Sidebar menu button -->
-          <button type="button" class="roomify-sidebar-user-icon navbar-toggle sidebar-menu-toggle roomify-sidebar-menu-toggle" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-          </button>
-
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-        <?php endif; ?>
-      </div>
-
-      <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-        <div class="navbar-collapse collapse">
-          <nav role="navigation">
-            <?php if (!empty($primary_nav)): ?>
-              <?php print render($primary_nav); ?>
-            <?php endif; ?>
-            <?php if (!empty($secondary_nav)): ?>
-              <?php print render($secondary_nav); ?>
+        <div class="roomify-site-name">
+          <div class="inner col-xs-10">
+            <?php if ($logo): ?>
+              <a class="logo" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
+                <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
+              </a>
             <?php endif; ?>
 
-            <!-- Link to open sidebar menu -->
+            <?php if (!empty($site_name)): ?>
+              <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
+            <?php endif; ?>
+          </div>
+        </div>
+
+        <div class="roomify-user-menu">
+          <div class="inner col-xs-1">
+          <!-- Link to open sidebar menu -->
             <span class="roomify-sidebar-link">
               <a class="roomify-sidebar-menu-toggle" href="#menu-toggle">
                 <!-- PRINT SVG USER ICON -->
                 <?php print(file_get_contents($directory . '/assets/images/user.svg')); ?>
               </a>
             </span>
-
-            <?php if (!empty($page['navigation'])): ?>
-              <?php print render($page['navigation']); ?>
-            <?php endif; ?>
-          </nav>
+          </div>
         </div>
-      <?php endif; ?>
+
+      </div>
     </div>
   </header>
 

--- a/themes/roomify/roomify_travel/templates/page--taxonomy--location.tpl.php
+++ b/themes/roomify/roomify_travel/templates/page--taxonomy--location.tpl.php
@@ -74,7 +74,21 @@
  */
 ?>
 
-<?php $directory = drupal_get_path('theme', 'roomify_travel');;?>
+<?php $directory = drupal_get_path('theme', 'roomify_travel'); ?>
+<!-- The overlay Menu -->
+<div id="roomify-main-menu-overlay" class="roomify-overlay">
+  <!-- Button to close the overlay navigation -->
+  <a href="javascript:void(0)" class="closebtn" onclick="document.getElementById('roomify-main-menu-overlay').style.display = 'none';">&times;</a>
+
+  <!-- Overlay content -->
+  <div class="overlay-content">
+    <?php 
+      $main_menu = menu_tree_output(menu_tree_all_data('main-menu', NULL, 2));
+      print drupal_render($main_menu);
+    ?>
+  </div>
+</div>
+
 <!-- Sidebar Content-->
 <div id="sidebar-wrapper">
   <div class="sidebar-nav">
@@ -93,60 +107,48 @@
   </div>
 <?php endif; ?>
 
-
 <div id="wrap">
   <header id="navbar" role="banner" class="roomify-header <?php print $navbar_classes; ?>">
     <div class="container">
       <div class="navbar-header">
-        <?php if ($logo): ?>
-          <a class="logo navbar-btn pull-left" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
-            <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
-          </a>
-        <?php endif; ?>
+        <div class="roomify-site-menu">
+          <div class="inner col-xs-1">
+            <button type="button" class="navbar-toggle" onclick='document.getElementById("roomify-main-menu-overlay").style.display = "block";'>
+              <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+          </div>
+        </div>
 
-        <?php if (!empty($site_name)): ?>
-          <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
-        <?php endif; ?>
-
-        <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-          <!-- Sidebar menu button -->
-          <button type="button" class="roomify-sidebar-user-icon navbar-toggle sidebar-menu-toggle roomify-sidebar-menu-toggle" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-          </button>
-
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-        <?php endif; ?>
-      </div>
-
-      <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-        <div class="navbar-collapse collapse">
-          <nav role="navigation">
-            <?php if (!empty($primary_nav)): ?>
-              <?php print render($primary_nav); ?>
-            <?php endif; ?>
-            <?php if (!empty($secondary_nav)): ?>
-              <?php print render($secondary_nav); ?>
+        <div class="roomify-site-name">
+          <div class="inner col-xs-10">
+            <?php if ($logo): ?>
+              <a class="logo" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
+                <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
+              </a>
             <?php endif; ?>
 
-            <!-- Link to open sidebar menu -->
+            <?php if (!empty($site_name)): ?>
+              <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
+            <?php endif; ?>
+          </div>
+        </div>
+
+        <div class="roomify-user-menu">
+          <div class="inner col-xs-1">
+          <!-- Link to open sidebar menu -->
             <span class="roomify-sidebar-link">
               <a class="roomify-sidebar-menu-toggle" href="#menu-toggle">
                 <!-- PRINT SVG USER ICON -->
                 <?php print(file_get_contents($directory . '/assets/images/user.svg')); ?>
               </a>
             </span>
-
-            <?php if (!empty($page['navigation'])): ?>
-              <?php print render($page['navigation']); ?>
-            <?php endif; ?>
-          </nav>
+          </div>
         </div>
-      <?php endif; ?>
+
+      </div>
     </div>
   </header>
 

--- a/themes/roomify/roomify_travel/templates/page.tpl.php
+++ b/themes/roomify/roomify_travel/templates/page.tpl.php
@@ -74,7 +74,21 @@
  */
 ?>
 
-<?php $directory = drupal_get_path('theme', 'roomify_travel');;?>
+<?php $directory = drupal_get_path('theme', 'roomify_travel'); ?>
+<!-- The overlay Menu -->
+<div id="roomify-main-menu-overlay" class="roomify-overlay">
+  <!-- Button to close the overlay navigation -->
+  <a href="javascript:void(0)" class="closebtn" onclick="document.getElementById('roomify-main-menu-overlay').style.display = 'none';">&times;</a>
+
+  <!-- Overlay content -->
+  <div class="overlay-content">
+    <?php 
+      $main_menu = menu_tree_output(menu_tree_all_data('main-menu', NULL, 2));
+      print drupal_render($main_menu);
+    ?>
+  </div>
+</div>
+
 <!-- Sidebar Content-->
 <div id="sidebar-wrapper">
   <div class="sidebar-nav">
@@ -97,55 +111,44 @@
   <header id="navbar" role="banner" class="roomify-header <?php print $navbar_classes; ?>">
     <div class="container">
       <div class="navbar-header">
-        <?php if ($logo): ?>
-          <a class="logo navbar-btn pull-left" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
-            <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
-          </a>
-        <?php endif; ?>
+        <div class="roomify-site-menu">
+          <div class="inner col-xs-1">
+            <button type="button" class="navbar-toggle" onclick='document.getElementById("roomify-main-menu-overlay").style.display = "block";'>
+              <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+          </div>
+        </div>
 
-        <?php if (!empty($site_name)): ?>
-          <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
-        <?php endif; ?>
-
-        <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-          <!-- Sidebar menu button -->
-          <button type="button" class="roomify-sidebar-user-icon navbar-toggle sidebar-menu-toggle roomify-sidebar-menu-toggle" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-          </button>
-
-          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-            <span class="sr-only"><?php print t('Toggle navigation'); ?></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-        <?php endif; ?>
-      </div>
-
-      <?php if (!empty($primary_nav) || !empty($secondary_nav) || !empty($page['navigation'])): ?>
-        <div class="navbar-collapse collapse">
-          <nav role="navigation">
-            <?php if (!empty($primary_nav)): ?>
-              <?php print render($primary_nav); ?>
-            <?php endif; ?>
-            <?php if (!empty($secondary_nav)): ?>
-              <?php print render($secondary_nav); ?>
+        <div class="roomify-site-name">
+          <div class="inner col-xs-10">
+            <?php if ($logo): ?>
+              <a class="logo" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>">
+                <img src="<?php print $logo; ?>" alt="<?php print t('Home'); ?>" />
+              </a>
             <?php endif; ?>
 
-            <!-- Link to open sidebar menu -->
+            <?php if (!empty($site_name)): ?>
+              <a class="name navbar-brand" href="<?php print $front_page; ?>" title="<?php print t('Home'); ?>"><?php print $site_name; ?></a>
+            <?php endif; ?>
+          </div>
+        </div>
+
+        <div class="roomify-user-menu">
+          <div class="inner col-xs-1">
+          <!-- Link to open sidebar menu -->
             <span class="roomify-sidebar-link">
               <a class="roomify-sidebar-menu-toggle" href="#menu-toggle">
                 <!-- PRINT SVG USER ICON -->
                 <?php print(file_get_contents($directory . '/assets/images/user.svg')); ?>
               </a>
             </span>
-
-            <?php if (!empty($page['navigation'])): ?>
-              <?php print render($page['navigation']); ?>
-            <?php endif; ?>
-          </nav>
+          </div>
         </div>
-      <?php endif; ?>
+
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
For e.g. Zopim, we should only enable the module after a roomify manager has enabled the integration on their control panel.