### PR TITLE
Add descriptions to fields to improve UX.

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -234,6 +234,7 @@ projects[geofield][version] = 2.3
 
 projects[geofield_gmap][version] = 2.x-dev
 projects[geofield_gmap][patch][] = https://www.drupal.org/files/issues/geofield_gmap-zoom_after_selecting_address-2562835-1.patch
+projects[geofield_gmap][patch][] = https://www.drupal.org/files/issues/geofield_gmap-allow_html_tags_description-2847341-1.patch
 
 projects[geolocation][version] = 1.6
 

--- a/modules/roomify/roomify_blog/roomify_blog.fields.inc
+++ b/modules/roomify/roomify_blog/roomify_blog.fields.inc
@@ -274,7 +274,7 @@ function roomify_blog_create_fields() {
       'bundle' => 'blog',
       'default_value' => NULL,
       'deleted' => 0,
-      'description' => '',
+      'description' => 'You may add new Areas, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/location" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',
@@ -321,7 +321,7 @@ function roomify_blog_create_fields() {
       'bundle' => 'blog',
       'default_value' => NULL,
       'deleted' => 0,
-      'description' => '',
+      'description' => 'You may add new Categories, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/category" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',
@@ -422,7 +422,7 @@ function roomify_blog_create_fields() {
         ),
       ),
       'deleted' => 0,
-      'description' => 'The last blogpost with this checked will be placed as top blogpost on /blog page.',
+      'description' => 'Check this post as featured blogpost.',
       'display' => array(
         'default' => array(
           'label' => 'above',

--- a/modules/roomify/roomify_listing/roomify_listing.fields.inc
+++ b/modules/roomify/roomify_listing/roomify_listing.fields.inc
@@ -776,7 +776,7 @@ function roomify_listing_create_property_fields($property_bundle) {
     $field_instances['roomify_property-standard_property-field_sp_property_type'] = array(
       'bundle' => $property_bundle,
       'default_value' => NULL,
-      'description' => '',
+      'description' => 'You may add new Property Types, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/property_type" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',
@@ -937,7 +937,7 @@ function roomify_listing_create_property_fields($property_bundle) {
     $field_instances['roomify_property-standard_property-field_sp_amenities'] = array(
       'bundle' => $property_bundle,
       'default_value' => NULL,
-      'description' => '',
+      'description' => 'You may add new Amenities, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/amenities" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',
@@ -975,7 +975,7 @@ function roomify_listing_create_property_fields($property_bundle) {
     $field_instances['roomify_property-standard_property-field_sp_area'] = array(
       'bundle' => $property_bundle,
       'default_value' => NULL,
-      'description' => '',
+      'description' => 'You may add new Areas, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/location" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',
@@ -1015,7 +1015,7 @@ function roomify_listing_create_property_fields($property_bundle) {
     $field_instances['roomify_property-standard_property-field_sp_area_type'] = array(
       'bundle' => $property_bundle,
       'default_value' => NULL,
-      'description' => '',
+      'description' => 'You may add new Area Types, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/area_type" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',

--- a/modules/roomify/roomify_system/roomify_system.install
+++ b/modules/roomify/roomify_system/roomify_system.install
@@ -581,3 +581,47 @@ function roomify_system_update_7034() {
     ->condition('name', 'editablefields')
     ->execute();
 }
+
+/**
+ * Update fields descriptions.
+ */
+function roomify_system_update_7035() {
+  $instance_info = field_read_instance('node', 'field_blog_area', 'blog');
+  $instance_info['description'] = 'You may add new Areas, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/location" target="_blank">this link</a>';
+  field_update_instance($instance_info);
+
+  $instance_info = field_read_instance('node', 'field_featured_blogpost', 'blog');
+  $instance_info['description'] = 'Check this post as featured blogpost';
+  field_update_instance($instance_info);
+
+  $instance_info = field_read_instance('node', 'field_blog_categories', 'blog');
+  $instance_info['description'] = 'You may add new Categories, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/category" target="_blank">this link</a>';
+  field_update_instance($instance_info);
+
+  $instance_info = field_read_instance('node', 'field_activity_type', 'activity');
+  $instance_info['description'] = 'You may add new Activities, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/activity" target="_blank">this link</a>';
+  field_update_instance($instance_info);
+
+  $instance_info = field_read_instance('node', 'field_map_coordinates', 'activity');
+  $instance_info['description'] = 'This will add a marker in a map on the content page and on the <a href="/things-to-do" target="_blank">Activities page</a>';
+  field_update_instance($instance_info);
+
+  foreach (array('casa_property', 'locanda_property') as $property_bundle) {
+    $instance_info = field_read_instance('roomify_property', 'field_sp_property_type', $property_bundle);
+    $instance_info['description'] = 'You may add new Property Types, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/property_type" target="_blank">this link</a>';
+    field_update_instance($instance_info);
+
+    $instance_info = field_read_instance('roomify_property', 'field_sp_amenities', $property_bundle);
+    $instance_info['description'] = 'You may add new Amenities, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/amenities" target="_blank">this link</a>';
+    field_update_instance($instance_info);
+
+    $instance_info = field_read_instance('roomify_property', 'field_sp_area', $property_bundle);
+    $instance_info['description'] = 'You may add new Areas, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/location" target="_blank">this link</a>';
+    field_update_instance($instance_info);
+
+    $instance_info = field_read_instance('roomify_property', 'field_sp_area_type', $property_bundle);
+    $instance_info['description'] = 'You may add new Area Types, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/area_type" target="_blank">this link</a>';
+    field_update_instance($instance_info);
+  }
+
+}

--- a/modules/roomify/roomify_things_to_do/roomify_things_to_do.fields.inc
+++ b/modules/roomify/roomify_things_to_do/roomify_things_to_do.fields.inc
@@ -296,7 +296,7 @@ function roomify_things_to_do_create_fields() {
       'bundle' => 'activity',
       'default_value' => array(),
       'deleted' => 0,
-      'description' => '',
+      'description' => 'You may add new Activities, check out the Manage Taxonomies link on the dashboard or follow <a href="/admin/structure/taxonomy/activity" target="_blank">this link</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',
@@ -413,7 +413,7 @@ function roomify_things_to_do_create_fields() {
       'bundle' => 'activity',
       'default_value' => NULL,
       'deleted' => 0,
-      'description' => '',
+      'description' => 'This will add a marker in a map on the content page and on the <a href="/things-to-do" target="_blank">Activities page</a>',
       'display' => array(
         'default' => array(
           'label' => 'above',


### PR DESCRIPTION
Fields like Categories or Areas in the blog haven't a description.

![screen shot 2017-01-20 at 10 13 22](https://cloud.githubusercontent.com/assets/6781952/22143153/4b08cf30-def9-11e6-8568-99d62e154f71.png)

We should review all fields and add a description to help users where we need that.
