### PR TITLE
Wrong departure date on listing enquiry.

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -964,8 +964,8 @@ function roomify_accommodation_booking_options_change_callback(&$form, $form_sta
 function roomify_accommodation_booking_confirmation_form_enquiry_submit($form, &$form_state) {
   $values = $form_state['values'];
 
-  $start_date = $values['start_date'];
-  $end_date = $values['end_date'];
+  $start_date = clone($values['start_date']);
+  $end_date = clone($values['end_date']);
   $end_date->sub(new DateInterval('PT1M'));
 
   $type_id = $form_state['values']['type_id'];


### PR DESCRIPTION
If I make an availability search for dates such as 2017/01/26 and 2017/01/31, if I chose to send an enquiry the departure date has a day less. (see screenshot)

<img width="1271" alt="wrong departure date" src="https://cloud.githubusercontent.com/assets/6781952/22289459/f13b0502-e2fb-11e6-8958-18dba39c7ee3.png">

All the process in conversations (offer for the booking) will be with the wrong date.
