### PR TITLE
Customer should not be able to remove Mandatory options.

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -265,6 +265,7 @@ function roomify_accommodation_booking_form_views_form_my_cart_default_alter(&$f
     if ($line_item->type == 'roomify_accommodation_booking') {
       $line_item_wrapper = entity_metadata_wrapper('commerce_line_item', $line_item);
 
+      $booking_id = $line_item->commerce_booking_reference[LANGUAGE_NONE][0]['target_id'];
       $type = bat_type_load($line_item_wrapper->commerce_booking_reference->booking_event_reference->event_bat_unit_reference->type_id->value());
 
       $options = roomify_accommodation_options_get_type_options($type);
@@ -309,6 +310,7 @@ function roomify_accommodation_booking_form_views_form_commerce_cart_form_defaul
     if ($line_item->type == 'roomify_accommodation_booking') {
       $line_item_wrapper = entity_metadata_wrapper('commerce_line_item', $line_item);
 
+      $booking_id = $line_item->commerce_booking_reference[LANGUAGE_NONE][0]['target_id'];
       $type = bat_type_load($line_item_wrapper->commerce_booking_reference->booking_event_reference->event_bat_unit_reference->type_id->value());
 
       $options = roomify_accommodation_options_get_type_options($type);


### PR DESCRIPTION
When a user makes a reservations, during the checkout he can be able to update the cart. We should disable the "Delete" button for mandatory options.
![screen shot 2017-01-30 at 12 40 14](https://cloud.githubusercontent.com/assets/6781952/22421956/34249b7a-e6ea-11e6-9875-880894a56f00.png)
