### PR TITLE
Roomify Manager should be able to translate contact form text.

### DIFF
--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -1415,6 +1415,7 @@ function roomify_listing_enquiry_form_submit($form, &$form_state) {
 function roomify_listing_enquiry_settings_form($form, &$form_state) {
   form_load_include($form_state, 'inc', 'variable_realm', 'variable_realm.variable');
   module_load_include('form.inc', 'variable');
+  _roomify_system_prepare_variables_realm();
 
   $form['roomify_submission_reply_page_title'] = variable_form_element(variable_get_info('roomify_submission_reply_page_title'));
 

--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -187,6 +187,9 @@ function _roomify_system_prepare_variables_realm() {
  * Form "Global Site Settings".
  */
 function roomify_system_global_site_settings_form($form, &$form_state) {
+  form_load_include($form_state, 'inc', 'variable_realm', 'variable_realm.variable');
+  _roomify_system_prepare_variables_realm();
+
   global $user;
 
   $allowed = FALSE;
@@ -198,8 +201,6 @@ function roomify_system_global_site_settings_form($form, &$form_state) {
       break;
     }
   }
-  form_load_include($form_state, 'inc', 'variable_realm', 'variable_realm.variable');
-  _roomify_system_prepare_variables_realm();
 
   $form['site_information'] = array(
     '#type' => 'fieldset',


### PR DESCRIPTION
As a Roomify Manager, in a multilanguage site, if I visit the "Enquiry Form settings" link in the dashboard I should be able to translate the form.