### PR TITLE
Guest references break booking creations

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -1549,6 +1549,11 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
         ($form_id == 'bat_booking_form' || $form_id == 'bat_booking_edit_form' || $form_id == 'bat_booking_edit_roomify_accommodation_booking_form')) {
       global $user;
 
+      // Update the profile reference field.
+      $form['booking_guest'][LANGUAGE_NONE][0]['target_id']['#attributes']['readonly'] = 'readonly';
+      $form['booking_guest'][LANGUAGE_NONE][0]['target_id']['#attributes']['style'] = 'background-color: #e4e4e4;';
+      $form['booking_guest'][LANGUAGE_NONE][0]['target_id']['#description'] = t('Use the "Create Billing information" link to add a new guest, or click "Search" to use a repeat guest\'s details.');
+
       // Remove the cancel button, users get access denied at the redirect.
       unset($form['actions']['delete']['#suffix']);
 

--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -888,7 +888,6 @@ function roomify_system_roomify_rights() {
       'unpublish own property',
       'unpublish own type',
       'edit meta tags',
-      'edit any commerce_customer_profile entity',
       'view any commerce_customer_profile entity',
       'create commerce_customer_profile entities',
     ),

--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -888,6 +888,9 @@ function roomify_system_roomify_rights() {
       'unpublish own property',
       'unpublish own type',
       'edit meta tags',
+      'edit any commerce_customer_profile entity',
+      'view any commerce_customer_profile entity',
+      'create commerce_customer_profile entities',
     ),
     'roomify manager' => array(
       'administer fields',


### PR DESCRIPTION
1. Guest references can break booking creation if a guest isn't referenced (nasty errors, then if persisted with, only an event is created, and no booking
2. Property owners do not have permissions necessary to search/add guest profiles