### PR TITLE
Guest information improvements

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -3235,6 +3235,7 @@ function roomify_accommodation_booking_references_dialog_entity_admin_paths() {
  */
 function roomify_accommodation_booking_references_dialog_widgets_alter(&$widgets) {
   $widgets['entityreference_autocomplete']['operations']['add']['function'] = 'roomify_accommodation_booking_references_dialog_entityreference_add_link';
+  $widgets['entityreference_autocomplete']['operations']['search']['function'] = 'roomify_accommodation_booking_references_dialog_entityreference_search_link';
 }
 
 /**
@@ -3250,4 +3251,17 @@ function roomify_accommodation_booking_references_dialog_entityreference_add_lin
   }
 
   return $add_links;
+}
+
+/**
+ * Custom - Search link callback for entity references.
+ */
+function roomify_accommodation_booking_references_dialog_entityreference_search_link($element, $widget_settings, $field, $instance) {
+  $search_link = references_dialog_get_field_search_links($element, $widget_settings, $field, $instance);
+
+  if ($element['#entity_type'] == 'bat_booking' && $element['#field_name'] == 'booking_guest') {
+    $search_link[0]['title'] = t('Search for existing Guest');
+  }
+
+  return $search_link;
 }

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -2124,6 +2124,10 @@ function roomify_accommodation_booking_commerce_checkout_complete($order) {
       if ($line_item->type == 'roomify_accommodation_booking') {
         $booking = bat_booking_load($line_item->commerce_booking_reference[LANGUAGE_NONE][0]['target_id']);
 
+        $booking->booking_guest[LANGUAGE_NONE][0]['target_id'] = $order->commerce_customer_billing[LANGUAGE_NONE][0]['profile_id'];
+
+        $booking->save();
+
         // Set event state to 'Booked'.
         $event = bat_event_load($booking->booking_event_reference[LANGUAGE_NONE][0]['target_id']);
 

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -1710,24 +1710,42 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
       else {
         $form['actions']['submit']['#submit'] = array_merge(array('roomify_accommodation_booking_edit_booking_form_submit'), $form['actions']['submit']['#submit']);
 
-        $line_item = commerce_line_item_load($form['#entity']->booking_line_item_reference[LANGUAGE_NONE][0]['target_id']);
+        $booking = $form['#entity'];
+
+        $line_item = commerce_line_item_load($booking->booking_line_item_reference[LANGUAGE_NONE][0]['target_id']);
         $order = commerce_order_load($line_item->order_id);
 
-        if (isset($order->commerce_customer_billing[LANGUAGE_NONE][0]['profile_id'])) {
-          $profile = commerce_customer_profile_load($order->commerce_customer_billing[LANGUAGE_NONE][0]['profile_id']);
+        if (isset($booking->booking_guest[LANGUAGE_NONE][0]['target_id'])) {
+          if ($profile = commerce_customer_profile_load($booking->booking_guest[LANGUAGE_NONE][0]['target_id'])) {
+            $form['profile'] = array(
+             '#type' => 'fieldset',
+               '#title' => t('Guest Details'),
+              '#group' => 'additional_settings',
+              '#weight' => -100,
+            );
 
-          $form['profile'] = array(
-           '#type' => 'fieldset',
-             '#title' => t('Guest Details'),
-            '#group' => 'additional_settings',
-            '#weight' => -100,
-          );
+            $profile_array = entity_view('commerce_customer_profile', array($profile->profile_id => $profile), 'customer');
 
-          $profile_array = entity_view('commerce_customer_profile', array($profile->profile_id => $profile), 'customer');
+            $form['profile']['info'] = array(
+              '#markup' => '<div class="field-label">' . t('Address:') . '</div>' . drupal_render($profile_array),
+            );
+          }
+        }
+        elseif (isset($order->commerce_customer_billing[LANGUAGE_NONE][0]['profile_id'])) {
+          if ($profile = commerce_customer_profile_load($order->commerce_customer_billing[LANGUAGE_NONE][0]['profile_id'])) {
+            $form['profile'] = array(
+             '#type' => 'fieldset',
+              '#title' => t('Guest Details'),
+              '#group' => 'additional_settings',
+              '#weight' => -100,
+            );
 
-          $form['profile']['info'] = array(
-            '#markup' => '<div class="field-label">' . t('Address:') . '</div>' . drupal_render($profile_array),
-          );
+            $profile_array = entity_view('commerce_customer_profile', array($profile->profile_id => $profile), 'customer');
+
+            $form['profile']['info'] = array(
+              '#markup' => '<div class="field-label">' . t('Address:') . '</div>' . drupal_render($profile_array),
+            );
+          }
         }
 
         $form['order'] = array(
@@ -1805,7 +1823,7 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
         $start_date = new DateTime($booking->booking_start_date[LANGUAGE_NONE][0]['value']);
         $end_date = new DateTime($booking->booking_end_date[LANGUAGE_NONE][0]['value']);
 
-        $event = bat_event_load($form['#entity']->booking_event_reference[LANGUAGE_NONE][0]['target_id']);
+        $event = bat_event_load($booking->booking_event_reference[LANGUAGE_NONE][0]['target_id']);
         $event_wrapper = entity_metadata_wrapper('bat_event', $event);
 
         $type = bat_type_load($event_wrapper->event_bat_unit_reference->type_id->value());
@@ -1889,7 +1907,7 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
         $start_date = new DateTime($booking->booking_start_date[LANGUAGE_NONE][0]['value']);
         $end_date = new DateTime($booking->booking_end_date[LANGUAGE_NONE][0]['value']);
 
-        $event = bat_event_load($form['#entity']->booking_event_reference[LANGUAGE_NONE][0]['target_id']);
+        $event = bat_event_load($booking->booking_event_reference[LANGUAGE_NONE][0]['target_id']);
         $event_wrapper = entity_metadata_wrapper('bat_event', $event);
 
         $type = bat_type_load($event_wrapper->event_bat_unit_reference->type_id->value());

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -1718,7 +1718,7 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
 
           $form['profile'] = array(
            '#type' => 'fieldset',
-             '#title' => t('Guest'),
+             '#title' => t('Guest Details'),
             '#group' => 'additional_settings',
             '#weight' => -100,
           );
@@ -1727,10 +1727,6 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
 
           $form['profile']['info'] = array(
             '#markup' => '<div class="field-label">' . t('Address:') . '</div>' . drupal_render($profile_array),
-          );
-
-          $form['profile']['edit'] = array(
-            '#markup' => '<div class="edit-profile">' . l(t('Edit customer profile'), 'admin/commerce/customer-profiles/' . $profile->profile_id . '/edit', array('query' => drupal_get_destination())) . '</div>',
           );
         }
 
@@ -1831,7 +1827,7 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
 
         $form['profile'] = array(
           '#type' => 'fieldset',
-          '#title' => t('Guest'),
+          '#title' => t('Guest Details'),
           '#group' => 'additional_settings',
           '#weight' => -100,
         );
@@ -1840,10 +1836,6 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
 
         $form['profile']['info'] = array(
           '#markup' => '<div class="field-label">' . t('Address:') . '</div>' . drupal_render($profile_array),
-        );
-
-        $form['profile']['edit'] = array(
-          '#markup' => '<div>' . l(t('Edit customer profile'), 'admin/commerce/customer-profiles/' . $profile->profile_id . '/edit', array('query' => drupal_get_destination())) . '</div>',
         );
 
         $form['order'] = array(
@@ -1919,7 +1911,7 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
 
         $form['profile'] = array(
           '#type' => 'fieldset',
-          '#title' => t('Guest'),
+          '#title' => t('Guest Details'),
           '#group' => 'additional_settings',
           '#weight' => -100,
         );
@@ -1930,9 +1922,6 @@ function roomify_accommodation_booking_form_alter(&$form, &$form_state, $form_id
           '#markup' => '<div class="field-label">' . t('Address:') . '</div>' . drupal_render($profile_array),
         );
 
-        $form['profile']['edit'] = array(
-          '#markup' => '<div>' . l(t('Edit customer profile'), 'admin/commerce/customer-profiles/' . $profile->profile_id . '/edit', array('query' => drupal_get_destination())) . '</div>',
-        );
         $form['order'] = array(
           '#type' => 'fieldset',
           '#title' => t('Order'),

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -2224,6 +2224,33 @@ function roomify_accommodation_booking_bat_fullcalendar_modal_content($entity_id
 }
 
 /**
+ * Implements hook_bat_fullcalendar_formatted_event_alter().
+ */
+function roomify_accommodation_booking_bat_fullcalendar_formatted_event_alter(&$formatted_event, $context) {
+  if ($formatted_event['type'] == 'availability' && isset($context['bat_event'])) {
+    $event = $context['bat_event'];
+
+    $query = new EntityFieldQuery();
+    $result = $query->entityCondition('entity_type', 'bat_booking')
+      ->fieldCondition('booking_event_reference', 'target_id', $event->event_id)
+      ->execute();
+
+    if (isset($result['bat_booking'])) {
+      $booking = reset($result['bat_booking']);
+      $booking = bat_booking_load($booking->booking_id);
+
+      if (isset($booking->booking_guest[LANGUAGE_NONE][0]['target_id'])) {
+        $customer_profile = commerce_customer_profile_load($booking->booking_guest[LANGUAGE_NONE][0]['target_id']);
+
+        if (isset($customer_profile->commerce_customer_address[LANGUAGE_NONE][0]['name_line'])) {
+          $formatted_event['title'] = $customer_profile->commerce_customer_address[LANGUAGE_NONE][0]['name_line'];
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_entity_presave().
  */
 function roomify_accommodation_booking_entity_presave($entity, $type) {

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -3180,3 +3180,25 @@ function roomify_accommodation_booking_references_dialog_entity_admin_paths() {
     ),
   );
 }
+
+/**
+ * Implements hook_references_dialog_widgets_alter().
+ */
+function roomify_accommodation_booking_references_dialog_widgets_alter(&$widgets) {
+  $widgets['entityreference_autocomplete']['operations']['add']['function'] = 'roomify_accommodation_booking_references_dialog_entityreference_add_link';
+}
+
+/**
+ * Custom - Add link callback for entity references.
+ */
+function roomify_accommodation_booking_references_dialog_entityreference_add_link($element, $widget_settings, $field, $instance) {
+  $add_links = references_dialog_entityreference_add_link($element, $widget_settings, $field, $instance);
+
+  if (isset($add_links[0]['title'])) {
+    if ($add_links[0]['title'] == t('Create Billing information')) {
+      $add_links[0]['title'] = t('Add new Guest');
+    }
+  }
+
+  return $add_links;
+}

--- a/modules/roomify/roomify_accommodation_booking/views/roomify_accommodation_booking.views_default.inc
+++ b/modules/roomify/roomify_accommodation_booking/views/roomify_accommodation_booking.views_default.inc
@@ -437,6 +437,7 @@ function roomify_accommodation_booking_views_default_views() {
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Search for existing guest';
   $handler->display->display_options['use_ajax'] = TRUE;
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'none';
@@ -450,7 +451,7 @@ function roomify_accommodation_booking_views_default_views() {
   $handler->display->display_options['fields']['commerce_customer_address_name_line']['table'] = 'field_data_commerce_customer_address';
   $handler->display->display_options['fields']['commerce_customer_address_name_line']['field'] = 'commerce_customer_address_name_line';
   $handler->display->display_options['fields']['commerce_customer_address_name_line']['label'] = 'Full name';
-  /* Field: Field: Telephone */
+  /* Field: Commerce Customer profile: Telephone */
   $handler->display->display_options['fields']['booking_telephone']['id'] = 'booking_telephone';
   $handler->display->display_options['fields']['booking_telephone']['table'] = 'field_data_booking_telephone';
   $handler->display->display_options['fields']['booking_telephone']['field'] = 'booking_telephone';
@@ -490,6 +491,8 @@ function roomify_accommodation_booking_views_default_views() {
 
   /* Display: Reference dialog Search */
   $handler = $view->new_display('references_dialog', 'Reference dialog Search', 'references_dialog_1');
+  $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['title'] = 'Search for existing guest';
   $handler->display->display_options['defaults']['style_options'] = FALSE;
   $handler->display->display_options['defaults']['row_plugin'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;

--- a/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
+++ b/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
@@ -3729,3 +3729,6 @@ fieldset legend {
     width: 80% !important;
   }
 }
+#references-dialog-page .view-customer-profiles td {
+  cursor: pointer;
+}

--- a/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
+++ b/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
@@ -457,3 +457,7 @@ fieldset {
     }
   }
 }
+
+#references-dialog-page .view-customer-profiles td {
+  cursor: pointer;
+}


### PR DESCRIPTION
- [x]  When a booking is made on the front end, the billing profile is not referenced in the 'guest' field 
- [x]  Remove the 'Edit customer profile' link in the Guest tab
- [x]  Rename the 'Guest' tab 'Guest Details'
- [x]  The billing profile details in the 'Guest' tab are not updated when a new billing profile is referenced in the 'Guest' field
- [x] The label for a booking in the availability calendar should be the 'Full name' of the billing profile referenced in the Guest field
- [x] Alter the references dialog link titles when adding or editing a booking: change 'Create Billing information' to 'Add new Guest', and change 'Search' to 'Search for existing guest' (titles must remain translatable) 