### PR TITLE
Admin Property Location GMAPS error

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -236,6 +236,7 @@ projects[file_entity][version] = 2.0-beta3
 projects[geofield][version] = 2.3
 
 projects[geofield_gmap][version] = 2.x-dev
+projects[geofield_gmap][patch][] = https://www.drupal.org/files/issues/fix-api-key-not-being-used-2746209-16.patch
 projects[geofield_gmap][patch][] = https://www.drupal.org/files/issues/geofield_gmap-zoom_after_selecting_address-2562835-1.patch
 projects[geofield_gmap][patch][] = https://www.drupal.org/files/issues/geofield_gmap-allow_html_tags_description-2847341-1.patch
 


### PR DESCRIPTION
Oops! Something went wrong.
This page didn't load Google Maps correctly. See the JavaScript console for technical details.

FireFox Webconsole shows:
"Google Maps API error: MissingKeyMapError https://developers.google.com/maps/documentation/javascript/error-messages#missing-key-map-error"

We have changed to GoDaddy Servers. We used the generated Google API Key for both Geofield Gmap under Content Authoring, as well as Geolocation Google Maps under Web Services.
Tried with and without the key, also generated new keys.

Current Maps shows fine on the frontpage, but new Admin Locations have the problem (even with current maps).

Kindly advise what the reason could be.