### PR TITLE
PETs duplicated after editing.

### DIFF
--- a/modules/casa/roomify_casa_pet/roomify_casa_pet.install
+++ b/modules/casa/roomify_casa_pet/roomify_casa_pet.install
@@ -69,6 +69,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "commerce-order" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -84,6 +85,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "bat_type", "roomify_conversation" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -99,6 +101,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "bat_type", "roomify_conversation" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -114,6 +117,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "message", "conversation" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -129,6 +133,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "user" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -144,6 +149,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "user" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -158,12 +164,8 @@ function _casa_create_pet_templates() {
     "cc_default" : "",
     "bcc_default" : "",
     "recipient_callback" : "",
-    "token_entity_types" : [
-      "commerce-line-item",
-      "commerce-order",
-      "roomify-property",
-      "bat-booking"
-    ],
+    "token_entity_types" : [ "commerce-line-item", "commerce-order", "roomify_property", "bat_booking" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -195,6 +197,7 @@ function _casa_create_pet_templates() {
     "bcc_default" : "",
     "recipient_callback" : "",
     "token_entity_types" : [ "bat_type", "bat_booking", "roomify_property" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -210,6 +213,7 @@ function _casa_create_pet_templates() {
      "bcc_default" : "",
      "recipient_callback" : "",
      "token_entity_types" : [ "bat_type", "bat_booking", "roomify_property" ],
+     "language" : "en",
      "rdf_mapping" : []
    }');
 
@@ -224,7 +228,8 @@ function _casa_create_pet_templates() {
     "cc_default" : "",
     "bcc_default" : "",
     "recipient_callback" : "",
-    "token_entity_types" : [ "conversation", "roomify-property" ],
+    "token_entity_types" : [ "conversation", "roomify_property" ],
+    "language" : "en",
     "rdf_mapping" : []
   }');
 
@@ -239,7 +244,7 @@ function _casa_create_pet_templates() {
     "cc_default" : "",
     "bcc_default" : "",
     "recipient_callback" : "",
-    "token_entity_types" : null,
+    "token_entity_types" : [ "roomify_property" ],
     "language" : "en",
     "rdf_mapping" : []
   }');
@@ -255,7 +260,7 @@ function _casa_create_pet_templates() {
     "cc_default" : "",
     "bcc_default" : "",
     "recipient_callback" : "",
-    "token_entity_types" : null,
+    "token_entity_types" : [ "roomify_property", "bat_booking" ],
     "language" : "en",
     "rdf_mapping" : []
   }');
@@ -686,4 +691,27 @@ function roomify_casa_pet_update_7015() {
   foreach ($items as $item) {
     $item->save();
   }
+}
+
+/**
+ * Update existing pets to define a default language (EN).
+ */
+function roomify_casa_pet_update_7016() {
+  $pets = db_select('pets', 'p')
+    ->fields('p', array('name'))
+    ->condition('language', 'en')
+    ->execute()
+    ->fetchAll();
+
+  foreach ($pets as $pet) {
+    db_delete('pets')
+      ->condition('name', $pet->name)
+      ->condition('language', '')
+      ->execute();
+  }
+
+  db_update('pets')
+    ->fields(array('language' => 'en'))
+    ->condition('language', '')
+    ->execute();
 }

--- a/modules/roomify/roomify_dashboard/plugins/content_types/manage_email_templates.inc
+++ b/modules/roomify/roomify_dashboard/plugins/content_types/manage_email_templates.inc
@@ -15,7 +15,7 @@ $plugin = array(
  */
 function roomify_dashboard_manage_email_templates_render($subtype, $conf, $args, $pane_context, $incoming_content) {
   $block = new stdClass();
-  $block->content = '<p>' . l('<strong>' . t('Manage Email Templates') . '</strong><br/>' . t('Here is where you may edit the email templates to change the text of emails that are automatically sent to users'), 'email-templates', array('html' => TRUE, 'attributes' => array('id' => 'dashboard-manage-email-templates'))) . '</p>';
+  $block->content = '<p>' . l('<strong>' . t('Manage Email Templates') . '</strong><br/>' . t('Here is where you may edit the email templates to change the text of emails that are automatically sent to users'), 'admin/bat/config/email-templates', array('html' => TRUE, 'attributes' => array('id' => 'dashboard-manage-email-templates'))) . '</p>';
 
   return $block;
 }

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.info
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.info
@@ -29,3 +29,4 @@ features[views_view][] = properties
 
 files[] = views/roomify_dashboard_handler_commerce_order_property_image.inc
 files[] = views/roomify_dashboard_filters_handler_filter_language_select.inc
+files[] = views/roomify_dashboard_handler_localized_edit_link.inc

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.info
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.info
@@ -28,3 +28,4 @@ features[views_view][] = form_submissions
 features[views_view][] = properties
 
 files[] = views/roomify_dashboard_handler_commerce_order_property_image.inc
+files[] = views/roomify_dashboard_filters_handler_filter_language_select.inc

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -257,6 +257,13 @@ function roomify_dashboard_views_data_alter(&$data) {
       'handler' => 'roomify_dashboard_handler_commerce_order_property_image',
     ),
   );
+  $data['pets']['localize_edit_link'] = array(
+    'field' => array(
+      'title' => t('Localized Edit link'),
+      'help' => t('An edit link with the selected language.'),
+      'handler' => 'roomify_dashboard_handler_localized_edit_link',
+    ),
+  );
 
   $data['pets']['language_select'] = array(
     'title' => t('Language select list'),

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -263,6 +263,6 @@ function roomify_dashboard_views_data_alter(&$data) {
     'group' => t('Previewable Email Template'),
     'help' => t('Filter by language, choosing from dropdown list.'),
     'filter' => array('handler' => 'roomify_dashboard_filters_handler_filter_language_select'),
-    'real field' => 'language',  
+    'real field' => 'language',
   );
 }

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -171,7 +171,7 @@ function roomify_dashboard_form_alter(&$form, &$form_state, $form_id) {
  * FORM_ID = pet_form.
  */
 function roomify_dashboard_form_pet_form_alter(&$form, &$form_state) {
-  $form['actions']['cancel']['#href'] = '/email-templates';
+  $form['actions']['cancel']['#href'] = '/admin/bat/config/email-templates';
 
   $form['#submit'][] = 'redirect_to_email_templates_view';
 }
@@ -180,7 +180,7 @@ function roomify_dashboard_form_pet_form_alter(&$form, &$form_state) {
  * Custom submit function to redirect users.
  */
 function redirect_to_email_templates_view(&$form, &$form_state) {
-  $form_state['redirect'] = 'email-templates';
+  $form_state['redirect'] = 'admin/bat/config/email-templates';
 }
 
 /**

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -257,4 +257,12 @@ function roomify_dashboard_views_data_alter(&$data) {
       'handler' => 'roomify_dashboard_handler_commerce_order_property_image',
     ),
   );
+
+  $data['pets']['language_select'] = array(
+    'title' => t('Language select list'),
+    'group' => t('Previewable Email Template'),
+    'help' => t('Filter by language, choosing from dropdown list.'),
+    'filter' => array('handler' => 'roomify_dashboard_filters_handler_filter_language_select'),
+    'real field' => 'language',  
+  );
 }

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -2525,11 +2525,15 @@ function roomify_dashboard_views_default_views() {
   $handler->display->display_options['fields']['name']['id'] = 'name';
   $handler->display->display_options['fields']['name']['table'] = 'pets';
   $handler->display->display_options['fields']['name']['field'] = 'name';
-  $handler->display->display_options['fields']['name']['label'] = 'Edit Template';
-  $handler->display->display_options['fields']['name']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['name']['alter']['text'] = 'Edit';
-  $handler->display->display_options['fields']['name']['alter']['make_link'] = TRUE;
-  $handler->display->display_options['fields']['name']['alter']['path'] = '/admin/structure/pets/manage/[name]';
+  $handler->display->display_options['fields']['name']['label'] = '';
+  $handler->display->display_options['fields']['name']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['name']['element_label_colon'] = FALSE;
+  /* Field: Previewable Email Template: Localized Edit link */
+  $handler->display->display_options['fields']['localize_edit_link']['id'] = 'localize_edit_link';
+  $handler->display->display_options['fields']['localize_edit_link']['table'] = 'pets';
+  $handler->display->display_options['fields']['localize_edit_link']['field'] = 'localize_edit_link';
+  $handler->display->display_options['fields']['localize_edit_link']['label'] = 'Edit Template';
+  $handler->display->display_options['fields']['localize_edit_link']['element_label_colon'] = FALSE;
   $handler->display->display_options['path'] = 'admin/bat/config/email-templates';
   $translatables['email_templates'] = array(
     t('Master'),

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -2416,7 +2416,8 @@ function roomify_dashboard_views_default_views() {
   $handler->display->display_options['title'] = 'Email Templates';
   $handler->display->display_options['use_ajax'] = TRUE;
   $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['access']['perm'] = 'administer previewable email templates';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
@@ -2556,6 +2557,7 @@ function roomify_dashboard_views_default_views() {
     t('Page'),
     t('Language'),
   );
+
   $export['email_templates'] = $view;
 
   $view = new view();

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -2414,30 +2414,30 @@ function roomify_dashboard_views_default_views() {
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['title'] = 'Email Templates';
+  $handler->display->display_options['use_ajax'] = TRUE;
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'none';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['exposed_form']['options']['autosubmit'] = TRUE;
   $handler->display->display_options['pager']['type'] = 'full';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
-  $handler->display->display_options['style_plugin'] = 'table';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '25';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['pager']['options']['id'] = '0';
+  $handler->display->display_options['pager']['options']['quantity'] = '9';
+  $handler->display->display_options['style_plugin'] = 'views_bootstrap_table_plugin_style';
   $handler->display->display_options['style_options']['columns'] = array(
     'pid' => 'pid',
-    'views_bulk_operations' => 'views_bulk_operations',
     'title' => 'title',
-    'url' => 'url',
+    'language_1' => 'language_1',
+    'name' => 'name',
   );
   $handler->display->display_options['style_options']['default'] = '-1';
   $handler->display->display_options['style_options']['info'] = array(
     'pid' => array(
       'sortable' => 0,
       'default_sort_order' => 'asc',
-      'align' => '',
-      'separator' => '',
-      'empty_column' => 0,
-    ),
-    'views_bulk_operations' => array(
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
@@ -2449,12 +2449,28 @@ function roomify_dashboard_views_default_views() {
       'separator' => '',
       'empty_column' => 0,
     ),
-    'url' => array(
-      'align' => '',
+    'language_1' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => 'views-align-center',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'name' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => 'views-align-center',
       'separator' => '',
       'empty_column' => 0,
     ),
   );
+  $handler->display->display_options['style_options']['bootstrap_styles'] = array(
+    'striped' => 'striped',
+    'bordered' => 'bordered',
+    'hover' => 'hover',
+    'condensed' => 'condensed',
+  );
+  $handler->display->display_options['style_options']['responsive'] = 0;
   /* Field: Previewable Email Template: Internal, numeric previewable email template ID */
   $handler->display->display_options['fields']['pid']['id'] = 'pid';
   $handler->display->display_options['fields']['pid']['table'] = 'pets';
@@ -2475,9 +2491,44 @@ function roomify_dashboard_views_default_views() {
   $handler->display->display_options['fields']['name']['alter']['text'] = 'Edit';
   $handler->display->display_options['fields']['name']['alter']['make_link'] = TRUE;
   $handler->display->display_options['fields']['name']['alter']['path'] = '/admin/structure/pets/manage/[name]';
+  /* Filter criterion: Previewable Email Template: Language select list */
+  $handler->display->display_options['filters']['language_select']['id'] = 'language_select';
+  $handler->display->display_options['filters']['language_select']['table'] = 'pets';
+  $handler->display->display_options['filters']['language_select']['field'] = 'language_select';
+  $handler->display->display_options['filters']['language_select']['group'] = 1;
+  $handler->display->display_options['filters']['language_select']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['language_select']['expose']['operator_id'] = 'language_select_op';
+  $handler->display->display_options['filters']['language_select']['expose']['label'] = 'Language select list';
+  $handler->display->display_options['filters']['language_select']['expose']['operator'] = 'language_select_op';
+  $handler->display->display_options['filters']['language_select']['expose']['identifier'] = 'language_select';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Previewable Email Template: Internal, numeric previewable email template ID */
+  $handler->display->display_options['fields']['pid']['id'] = 'pid';
+  $handler->display->display_options['fields']['pid']['table'] = 'pets';
+  $handler->display->display_options['fields']['pid']['field'] = 'pid';
+  $handler->display->display_options['fields']['pid']['exclude'] = TRUE;
+  /* Field: Previewable Email Template: Label */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'pets';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = 'Template Name';
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  /* Field: Previewable Email Template: Language */
+  $handler->display->display_options['fields']['language_1']['id'] = 'language_1';
+  $handler->display->display_options['fields']['language_1']['table'] = 'pets';
+  $handler->display->display_options['fields']['language_1']['field'] = 'language';
+  /* Field: Previewable Email Template: Machine-readable name */
+  $handler->display->display_options['fields']['name']['id'] = 'name';
+  $handler->display->display_options['fields']['name']['table'] = 'pets';
+  $handler->display->display_options['fields']['name']['field'] = 'name';
+  $handler->display->display_options['fields']['name']['label'] = 'Edit Template';
+  $handler->display->display_options['fields']['name']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['name']['alter']['text'] = 'Edit';
+  $handler->display->display_options['fields']['name']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['name']['alter']['path'] = '/admin/structure/pets/manage/[name]';
   $handler->display->display_options['path'] = 'email-templates';
   $translatables['email_templates'] = array(
     t('Master'),
@@ -2501,7 +2552,9 @@ function roomify_dashboard_views_default_views() {
     t('Template Name'),
     t('Edit Template'),
     t('Edit'),
+    t('Language select list'),
     t('Page'),
+    t('Language'),
   );
   $export['email_templates'] = $view;
 

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -2529,7 +2529,7 @@ function roomify_dashboard_views_default_views() {
   $handler->display->display_options['fields']['name']['alter']['text'] = 'Edit';
   $handler->display->display_options['fields']['name']['alter']['make_link'] = TRUE;
   $handler->display->display_options['fields']['name']['alter']['path'] = '/admin/structure/pets/manage/[name]';
-  $handler->display->display_options['path'] = 'email-templates';
+  $handler->display->display_options['path'] = 'admin/bat/config/email-templates';
   $translatables['email_templates'] = array(
     t('Master'),
     t('Email Templates'),

--- a/modules/roomify/roomify_dashboard/views/roomify_dashboard_filters_handler_filter_language_select.inc
+++ b/modules/roomify/roomify_dashboard/views/roomify_dashboard_filters_handler_filter_language_select.inc
@@ -13,17 +13,9 @@ class roomify_dashboard_filters_handler_filter_language_select extends views_han
   /**
    * {@inheritdoc}
    */
-
   public function get_value_options() {
-    $languages_list = array();
-
-    $results = db_select('languages', 'l')
-      ->fields('l')
-      ->execute()
-      ->fetchAll();
-
-    foreach ($results as $result) {
-      $languages_list[$result->language] = $result->name;
+    foreach (locale_language_list() as $language => $name) {
+      $languages_list[$language] = $name;
     }
 
     $this->value_options = $languages_list;

--- a/modules/roomify/roomify_dashboard/views/roomify_dashboard_filters_handler_filter_language_select.inc
+++ b/modules/roomify/roomify_dashboard/views/roomify_dashboard_filters_handler_filter_language_select.inc
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Contains a Views field handler to take care of displaying language filter as select.
+ */
+
+/**
+ *
+ */
+class roomify_dashboard_filters_handler_filter_language_select extends views_handler_filter_in_operator {
+
+  /**
+   * {@inheritdoc}
+   */
+
+  public function get_value_options() {
+    $languages_list = array();
+
+    $results = db_select('languages', 'l')
+      ->fields('l')
+      ->execute()
+      ->fetchAll();
+
+    foreach ($results as $result) {
+      $languages_list[$result->language] = $result->name;
+    }
+
+    $this->value_options = $languages_list;
+
+    return $languages_list;
+  }
+
+}

--- a/modules/roomify/roomify_dashboard/views/roomify_dashboard_handler_localized_edit_link.inc
+++ b/modules/roomify/roomify_dashboard/views/roomify_dashboard_handler_localized_edit_link.inc
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ *
+ */
+class roomify_dashboard_handler_localized_edit_link extends views_handler_field {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function construct() {
+    parent::construct();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $this->ensure_my_table();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render($values) {
+    $url = url('admin/structure/pets/manage/' . $values->pets_name);
+    foreach (language_list() as $code => $language) {
+      if ($code == $values->pets_language) {
+        $url = url('admin/structure/pets/manage/' . $values->pets_name, array('language' => $language));
+      }
+    }
+    return l(t('Edit Template'), $url);
+  }
+
+}

--- a/modules/roomify/roomify_dashboard/views/roomify_dashboard_handler_localized_edit_link.inc
+++ b/modules/roomify/roomify_dashboard/views/roomify_dashboard_handler_localized_edit_link.inc
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Contains a Views field handler to take care of a localize link to edit pets.
  */
 
 /**

--- a/themes/roomify/roomify_adminimal_theme/templates/views-view-field--email-templates--page--language-1.tpl.php
+++ b/themes/roomify/roomify_adminimal_theme/templates/views-view-field--email-templates--page--language-1.tpl.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * This template is used to print a single field in a view.
+ *
+ * It is not actually used in default Views, as this is registered as a theme
+ * function which has better performance. For single overrides, the template is
+ * perfectly okay.
+ *
+ * Variables available:
+ * - $view: The view object
+ * - $field: The field handler object that can process the input
+ * - $row: The raw SQL result that can be used
+ * - $output: The processed output that will normally be used.
+ *
+ * When fetching output from the $row, this construct should be used:
+ * $data = $row->{$field->field_alias}
+ *
+ * The above will guarantee that you'll always get the correct data,
+ * regardless of any changes in the aliasing that might happen if
+ * the view is modified.
+ */
+?>
+<?php
+$language_list = locale_language_list();
+
+if (isset($language_list[$output])) {
+  print $language_list[$output];
+}
+else {
+  print $output;
+}
+?>


### PR DESCRIPTION
Updating a PET in a multilanguage site will duplicate it. I think we should define a default language (EN) for pets on installation and update existing templates.

![screen shot 2017-02-13 at 10 07 50](https://cloud.githubusercontent.com/assets/6781952/22877149/51d4513e-f1d4-11e6-90aa-70da82442e34.png)
