### PR TITLE
Update search_api_sorts to 1.7

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -403,7 +403,7 @@ projects[search_api_ranges][download][type] = git
 projects[search_api_ranges][download][url] = https://git.drupal.org/project/search_api_ranges.git
 projects[search_api_ranges][download][revision] = c769589f3aa90a7413401169ce520f891bee7e20
 
-projects[search_api_sorts][version] = 1.6
+projects[search_api_sorts][version] = 1.7
 
 projects[services][version] = 3.18
 


### PR DESCRIPTION
There is a SA for search_api_sorts: https://www.drupal.org/node/2852922 It's mitigated by the fact that an attacker must have a role with permission 'administer search_api'. So, not critical to get in but let's get it in 1.3.4.