### PR TITLE
Update metatag to 1.21

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -318,7 +318,7 @@ projects[menu_admin_per_menu][patch][] = https://www.drupal.org/files/issues/int
 projects[message][version] = 1.12
 projects[message][patch][] = https://www.drupal.org/files/issues/text-sanitized.patch
 
-projects[metatag][version] = 1.20
+projects[metatag][version] = 1.21
 
 projects[mimemail][version] = 1.0-beta4
 


### PR DESCRIPTION
There is a SA for metatag: https://www.drupal.org/node/2852922 It's mitigated by the fact that a site must have a page with sensitive data in the page title that varies per logged in user. So, not critical to get in but let's get it in 1.3.4.