### PR TITLE
Add Booking's options line item label.

### DIFF
--- a/modules/roomify/roomify_accommodation_options/roomify_accommodation_options.module
+++ b/modules/roomify/roomify_accommodation_options/roomify_accommodation_options.module
@@ -450,7 +450,7 @@ function roomify_accommodation_option_line_item_configuration($line_item_type) {
 /**
  * Implements hook_line_item_title().
  */
-function roomify_accommodation_options_line_item_title($line_item) {
+function roomify_accommodation_option_line_item_title($line_item) {
   // Use the line item's label for the title.
   return ($line_item->line_item_label);
 }


### PR DESCRIPTION
Options don't have a label.

![screen shot 2017-02-20 at 17 30 02](https://cloud.githubusercontent.com/assets/6781952/23133698/4bdb0246-f792-11e6-8d63-f3feb632f458.png)
