### PR TITLE
Error in upgrading from 1.3.3 to 1.3.4

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.install
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.install
@@ -344,8 +344,9 @@ function roomify_accommodation_booking_update_7010() {
     ->condition('booking_id', NULL)
     ->execute()
     ->fetchAllKeyed(0, 0);
-
-  db_delete('job_schedule')
-    ->condition('item_id', $item_ids, 'IN')
-    ->execute();
+  if (!empty($item_ids)) {
+    db_delete('job_schedule')
+      ->condition('item_id', $item_ids, 'IN')
+      ->execute();
+  }
 }


### PR DESCRIPTION
I am receiving the following error when I run update.php

"The following updates returned messages

roomify_accommodation_booking module

Update #7010

`Failed: PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '))' at line 1: DELETE FROM {job_schedule} WHERE (item_id IN ()) ; Array ( ) in roomify_accommodation_booking_update_7010() (line 350 of /profiles/roomify/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.install).`"