### PR TITLE
Multi-Unit Property Booking on Property Main Page not Working

### DIFF
--- a/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
+++ b/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
@@ -40,7 +40,9 @@ Drupal.behaviors.roomifyTravelScripts = {
       // Get the index of this tab
       tabIndex = $("li").index($tabParent);
       // Open the appropriate tab
-      $( '#ui-id-' + $id ).click();
+      $('#ui-id-' + $id).click();
+
+      document.getElementById('property-types').scrollIntoView();
     }
 
     // Hide overlay of slides without a title or a description.


### PR DESCRIPTION
Going to the Miles Boutique Hotel (Multi-Unit Property), there is a facility to book (without going to the rooms pages).
When trying to book from the property frontpage, nothing happens and the browser (firefox) just goes down to the featured properties tag.
An indication to first go to rooms or autoselect a room may be helpful.
Many thanks and regards, Mathys
