### PR TITLE
Move the Redirect fieldset inside a vertical tab

### DIFF
--- a/modules/roomify/roomify_system/roomify_system.module
+++ b/modules/roomify/roomify_system/roomify_system.module
@@ -2103,6 +2103,12 @@ function roomify_system_form_alter(&$form, &$form_state, $form_id) {
       unset($form['actions']['preview_changes']);
     }
   }
+
+  if (isset($form['redirect'])) {
+    if ($form['redirect']['#type'] == 'fieldset') {
+      $form['redirect']['#group'] = 'additional_settings';
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
We should move the fieldset for Roomify Properties and Types.

![screen shot 2017-03-03 at 12 30 09](https://cloud.githubusercontent.com/assets/6781952/23549820/449e2ede-000e-11e7-8222-81136635139b.png)
