### PR TITLE
Error on translated email templates.

### DIFF
--- a/modules/roomify/roomify_dashboard/views/roomify_dashboard_handler_localized_edit_link.inc
+++ b/modules/roomify/roomify_dashboard/views/roomify_dashboard_handler_localized_edit_link.inc
@@ -28,10 +28,10 @@ class roomify_dashboard_handler_localized_edit_link extends views_handler_field 
    * {@inheritdoc}
    */
   public function render($values) {
-    $url = url('admin/structure/pets/manage/' . $values->pets_name);
+    $url = url('admin/structure/pets/manage/' . $values->pets_name, array('absolute' => TRUE));
     foreach (language_list() as $code => $language) {
       if ($code == $values->pets_language) {
-        $url = url('admin/structure/pets/manage/' . $values->pets_name, array('language' => $language));
+        $url = url('admin/structure/pets/manage/' . $values->pets_name, array('language' => $language, 'absolute' => TRUE));
       }
     }
     return l(t('Edit Template'), $url);


### PR DESCRIPTION
If I visit the site in a different language and I try to edit translated email templates I get a 404.
<img width="1247" alt="screen shot 2017-03-06 at 12 51 59" src="https://cloud.githubusercontent.com/assets/6781952/23608892/b80a870a-026b-11e7-8970-b56efd0441f5.png">
