### PR TITLE
Incorrect end date and nights in commerce item line 

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -1118,6 +1118,7 @@ function roomify_accommodation_booking_confirmation_form_submit($form, &$form_st
 
   $start_date = $values['start_date'];
   $end_date = $values['end_date'];
+  $temp_end_date = clone($end_date);
   $end_date->sub(new DateInterval('PT1M'));
 
   $type_id = $values['type_id'];
@@ -1172,7 +1173,7 @@ function roomify_accommodation_booking_confirmation_form_submit($form, &$form_st
     $product = commerce_product_load($product_id);
     $line_item = commerce_product_line_item_new($product, 1, 0, array(), 'roomify_accommodation_booking');
 
-    $line_item->line_item_label = roomify_system_get_line_item_label($type, $property, $start_date, $end_date, $values['nights']);
+    $line_item->line_item_label = roomify_system_get_line_item_label($type, $property, $start_date, $temp_end_date, $values['nights']);
 
     // Add line item to cart.
     $line_item = commerce_cart_product_add($user->uid, $line_item, FALSE);


### PR DESCRIPTION
In `roomify_accommodation_booking_confirmation_form_submit()`, `bat_event_get_matching_units()` and `bat_event_create()` should be based on temporary calculated end date (minus one day) but `roomify_system_get_line_item_label()` and `$booking->booking_end_date` should be based on the effective booking end date. Otherwise, the commerce item line is saved with the incorrect number of nights and incorrect end date.