### PR TITLE
Add provider name to bookings export

### DIFF
--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -79,6 +79,17 @@ function roomify_dashboard_views_pre_render(&$view) {
         unset($result->bat_types_bat_units_name);
       }
     }
+
+    if ($view->current_display == 'views_data_export_1') {
+      foreach ($results as $key => $result) {
+        if ($result->bat_bookings_type == 'roomify_accommodation_booking') {
+          $result->bat_bookings_type = 'Standard';
+        }
+        elseif ($result->bat_bookings_type == 'ical') {
+          $result->bat_bookings_type = $result->field_ical_type;
+        }
+      }
+    }
   }
 
   if ($view->name == 'properties') {

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -1081,6 +1081,26 @@ function roomify_dashboard_views_default_views() {
   $handler->display->display_options['fields']['commerce_customer_address_postal_code']['relationship'] = 'booking_guest_target_id';
   $handler->display->display_options['fields']['commerce_customer_address_postal_code']['label'] = 'ZIP - Postal Code';
   $handler->display->display_options['fields']['commerce_customer_address_postal_code']['element_label_colon'] = FALSE;
+  /* Field: BAT Booking: Type */
+  $handler->display->display_options['fields']['type_1']['id'] = 'type_1';
+  $handler->display->display_options['fields']['type_1']['table'] = 'bat_bookings';
+  $handler->display->display_options['fields']['type_1']['field'] = 'type';
+  $handler->display->display_options['fields']['type_1']['label'] = 'Provider';
+  $handler->display->display_options['fields']['type_1']['machine_name'] = TRUE;
+  /* Field: BAT Booking: iCal type */
+  $handler->display->display_options['fields']['field_ical_type']['id'] = 'field_ical_type';
+  $handler->display->display_options['fields']['field_ical_type']['table'] = 'field_data_field_ical_type';
+  $handler->display->display_options['fields']['field_ical_type']['field'] = 'field_ical_type';
+  $handler->display->display_options['fields']['field_ical_type']['label'] = '';
+  $handler->display->display_options['fields']['field_ical_type']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_ical_type']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_ical_type']['settings'] = array(
+    'conditions' => array(
+      0 => array(
+        'condition' => '',
+      ),
+    ),
+  );
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Events: State (event_state_reference) */
@@ -2074,6 +2094,7 @@ function roomify_dashboard_views_default_views() {
     t('Address'),
     t('City'),
     t('ZIP - Postal Code'),
+    t('Provider'),
     t('Label'),
     t('Start Date (booking_start_date)'),
     t('End Date (booking_end_date)'),


### PR DESCRIPTION
When exporting bookings, the external provider's name (if any) should be listed. (e.g. booking.com, AirBnB, etc)