### PR TITLE
Error on saving pet templates

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -362,7 +362,7 @@ projects[pathauto_entity][version] = 1.0
 projects[pet][version] = 1.0-rc1
 projects[pet][patch][] = https://www.drupal.org/files/pet-add-rules-state-2092195-1.patch
 projects[pet][patch][] = https://www.drupal.org/files/issues/pet-specify_entity_types_for_tokens-2612754-1.patch
-projects[pet][patch][] = https://www.drupal.org/files/issues/multilanguage-support-2727733-5.patch
+projects[pet][patch][] = https://www.drupal.org/files/issues/multilanguage-support-2727733-6.patch
 
 projects[plupload][version] = 1.7
 ; https://www.drupal.org/node/2106583


### PR DESCRIPTION
When saving a PET on a multilanguage site, the one that is updated is the last in the db (based on the pet machine_name) and not the right one. For example, if I have the same PET in different languages, the one saved will always be the last in the DB rows.