### PR TITLE
Booking Constraints form does not work

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -264,7 +264,7 @@ projects[google_tag][version] = 1.0
 projects[group][version] = 1.0-beta6
 projects[group][patch][] = https://www.drupal.org/files/issues/group-profile2_integration-2701803-1.patch
 
-projects[jquery_update][version] = 3.0-alpha4
+projects[jquery_update][version] = 3.0-alpha3
 
 projects[job_scheduler][type] = module
 projects[job_scheduler][download][type] = git

--- a/test/behat/features/06_constraints.feature
+++ b/test/behat/features/06_constraints.feature
@@ -90,3 +90,18 @@ Feature: Global Booking Constraints
     Then I fill in "roomify_accommodation_booking_future_limit[value]" with "1"
     And I select "31104000" from "roomify_accommodation_booking_future_limit[multiplier]"
     And I press "Save configuration"
+
+  Scenario: "Booking Constraints" field widget
+    Given I am logged in as a user with the "roomify manager" role
+    Then I visit "admin/bat/config/types/manage/3/edit"
+    Then I should see "Booking Constraints"
+    Then I press "Set min/max period"
+    And I wait for AJAX to finish
+    And I should see "Minimum Booking Length is"
+    And I should see "Maximum Booking Length is"
+    And I should see "Only if booking starts on a specific day"
+    Then I click on the element with css selector "#edit-bat-constraints-range-und-add-more"
+    And I wait for AJAX to finish
+    Then I click on the element with css selector "#edit-bat-constraints-range-und-1-group-conditions-add-checkin-day"
+    And I wait for AJAX to finish
+    And I should see "Booking start day must be"


### PR DESCRIPTION
I try rfa with platform.sh and installing in local from 1.3.6 archive tag. Both have the same issue: ajax widget forms don't work.

When i edit 'My vacation rental' (from example) or 'Casa Sul Mare' (from platform.sh), i want to add or edit 'Booking constraints' or 'rates range' but none work. I can save the 2 default fields for rate range, but i can't add new items.

No errors are displayed, or logged.

I try to add Roomify Rates from admin/bat/config/rate. This work, i can create them but they aren't linked to my bat_type. So when i search for a booking for a week for example, price is only calculated with default price * number of days.

Looks very promising, but can't make a thing work as expected.

Can you help me to debug this please ?