### PR TITLE
Bad currency for new enquiries

### DIFF
--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -1393,7 +1393,7 @@ function roomify_listing_enquiry_form_submit($form, &$form_state) {
 
   $conversation->conversation_book_price[LANGUAGE_NONE][0] = array(
     'amount' => ($offer_amount == 0) ? $values['price'] * 100 : $offer_amount,
-    'currency_code' => 'USD',
+    'currency_code' => commerce_default_currency(),
     'data' => array(
       'components' => array(),
     ),


### PR DESCRIPTION
New enquiries are automatically set with USD as default currency. 
It would be better with Drupal Commerce default currency.

In /profiles/roomify/modules/roomify/roomify_listing/roomify_listing.module, at line 1367, replace:
`'currency_code' => 'USD',`

with:
`'currency_code' => commerce_default_currency(),`