### PR TITLE
Access to conversations

### DIFF
--- a/modules/roomify/roomify_conversations/roomify_conversations.module
+++ b/modules/roomify/roomify_conversations/roomify_conversations.module
@@ -1855,3 +1855,28 @@ function roomify_conversations_inquiry_render($conversation) {
 
   return $output;
 }
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function roomify_conversations_query_roomify_conversation_access_alter(QueryAlterableInterface $query) {
+  // Look for an event base table to pass to the query altering function or
+  // else assume we don't have the tables we need to establish order related
+  // altering right now.
+  foreach ($query->getTables() as $table) {
+    if ($table['table'] === 'roomify_conversations') {
+      $query->leftJoin('field_data_conversation_owner_user_ref', 'user_ref', 'roomify_conversations.conversation_id = user_ref.entity_id');
+
+      bat_entity_access_query_alter($query, 'roomify_conversation', $table['alias']);
+
+      break;
+    }
+  }
+}
+
+/**
+ * Implements hook_bat_entity_access_view_condition_roomify_conversation_alter().
+ */
+function roomify_conversations_bat_entity_access_view_condition_roomify_conversation_alter(&$conditions, $context) {
+  $conditions->condition('user_ref.conversation_owner_user_ref_target_id', $context['account']->uid);
+}

--- a/modules/roomify/roomify_conversations/roomify_conversations.pages_default.inc
+++ b/modules/roomify/roomify_conversations/roomify_conversations.pages_default.inc
@@ -19,11 +19,12 @@ function roomify_conversations_default_page_manager_pages() {
   $page->access = array(
     'plugins' => array(
       0 => array(
-        'name' => 'perm',
+        'name' => 'php',
         'settings' => array(
-          'perm' => 'view own roomify_conversation entities',
+          'description' => '',
+          'php' => '$conversation = $contexts[\'argument_entity_id:roomify_conversation_1\']->data;
+  return roomify_conversation_access(\'view\', $conversation);',
         ),
-        'context' => 'logged-in-user',
         'not' => FALSE,
       ),
     ),
@@ -76,6 +77,8 @@ function roomify_conversations_default_page_manager_pages() {
   $display->cache = array();
   $display->title = 'Conversation %roomify_conversation:conversation-id';
   $display->uuid = '9f5a56b0-08e8-4ad2-8e77-cea38515974d';
+  $display->storage_type = 'page_manager';
+  $display->storage_id = 'page_conversation__panel';
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -2869,7 +2869,8 @@ function roomify_dashboard_views_default_views() {
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['title'] = 'Contact Form Submissions';
   $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['access']['perm'] = 'view any entityform';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';


### PR DESCRIPTION
Hello,
Thank you for Roomify for Accommodations!
I've downloaded it and installed it on local machine to get more familiar with it.
It seems that each user (guest or owner) can view every conversation by changing the address URL 
Example: if from the dashboard user clicks on their own conversation and is taken to page ... /conversation/5 , if they  change the number "5" to any previous number, they can view conversations, even if they did not originally participated in it, and reply to them.
I've checked permissions and they are set to "View own conversations of any type", so they should not be able to view conversations that they did not participate in?
I'm wondering if I'm missing something in permissions..
Thank you
Ella

