### PR TITLE
Sync the default cost field of types with the standard nightly rate.

### DIFF
--- a/modules/roomify/roomify_listing/roomify_listing.fields.inc
+++ b/modules/roomify/roomify_listing/roomify_listing.fields.inc
@@ -2576,7 +2576,7 @@ function roomify_listing_create_standard_type_fields($type_bundle) {
     $field_instances['bat_type-standard_type-field_st_default_price'] = array(
       'bundle' => $type_bundle,
       'default_value' => NULL,
-      'description' => '',
+      'description' => 'Change this value to update the default night price of your property. This will override the Standard Rate.',
       'display' => array(
         'default' => array(
           'label' => 'above',

--- a/modules/roomify/roomify_listing/roomify_listing.install
+++ b/modules/roomify/roomify_listing/roomify_listing.install
@@ -1300,3 +1300,14 @@ function roomify_listing_update_7033() {
   }
   drupal_flush_all_caches();
 }
+
+/**
+ * Add description to Default Cost field.
+ */
+function roomify_listing_update_7034() {
+  foreach (array('home', 'room') as $type_bundle) {
+    $instance_info = field_read_instance('bat_type', 'field_st_default_price', $type_bundle);
+    $instance_info['description'] = 'Change this value to update the default night price of your property. This will override the Standard Rate.';
+    field_update_instance($instance_info);
+  }
+}

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -397,11 +397,40 @@ function roomify_listing_entity_update($entity, $type) {
           variable_set('roomify_max_property_type_capacity', $max_capacity[0]['value']);
         }
       }
+      // Check if a default price is set.
+      if (isset($entity->field_st_default_price)) {
+        $default_price = field_get_items('bat_type', $entity, 'field_st_default_price');
+        if (!empty($default_price)) {
+          // Update the standard night rate with the default price.
+          $standard_rates = roomify_rate_get_rates('standard', $entity->type_id);
+          if (!empty($standard_rates)) {
+            foreach ($standard_rates as $rate) {
+              if ($rate->type == 'standard' && isset($rate->data['standard']) && $rate->data['standard']) {
+                $rate->rate_default_rate[LANGUAGE_NONE] = $default_price;
+                field_attach_update('roomify_rate', $rate);
+              }
+            }
+          }
+        }
+      }
     }
 
     // Re-index the Property after changes to the type.
     if (module_exists('search_api') && isset($entity->field_st_property_reference[LANGUAGE_NONE][0]['target_id'])) {
       search_api_track_item_change('roomify_property', array($entity->field_st_property_reference[LANGUAGE_NONE][0]['target_id']));
+    }
+  }
+  if ($type == 'roomify_rate') {
+    if ($entity->type == 'standard') {
+      // Check if the standard night rate is going to be updated.
+      if (isset($entity->data['standard']) && $entity->data['standard']) {
+        if (isset($entity->rate_default_rate)) {
+          $bat_type = bat_type_load($entity->rate_bat_type_reference[LANGUAGE_NONE][0]['target_id']);
+          // Update the default price of the type.
+          $bat_type->field_st_default_price = $entity->rate_default_rate;
+          field_attach_update('bat_type', $bat_type);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
When a user update the "Default Cost" field from a type, the standard rate (nightly) should be updated with the new value and vice versa.