### PR TITLE
New add-on with price per day per person

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,5 +5,6 @@ projects[drupal][version] = 7.54
 ; Patches for Core
 projects[drupal][patch][] = "http://drupal.org/files/issues/install-redirect-on-empty-database-728702-36.patch"
 projects[drupal][patch][] = "http://drupal.org/files/1275902-15-entity_uri_callback-D7.patch"
+projects[drupal][patch][] = "https://www.drupal.org/files/issues/DATE_RFC7231-2877243-1.patch"
 projects[drupal][patch][] = "patches/9to10_menu_max_parts.patch"
 projects[drupal][patch][] = "patches/exclude_flag_robottxt.patch"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -41,7 +41,7 @@ projects[roomify_property][subdir] = roomify
 projects[roomify_channel_connector][type] = module
 projects[roomify_channel_connector][download][type] = git
 projects[roomify_channel_connector][download][url] = https://github.com/Roomify/roomify_channel_connector_drupal.git
-projects[roomify_channel_connector][download][tag] = 1.12
+projects[roomify_channel_connector][download][tag] = 1.13
 projects[roomify_channel_connector][directory_name] = roomify_channel_connector
 projects[roomify_channel_connector][subdir] = roomify
 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -271,7 +271,7 @@ projects[job_scheduler][download][type] = git
 projects[job_scheduler][download][url] = https://git.drupal.org/project/job_scheduler.git
 projects[job_scheduler][download][revision] = 9baaba6bebd34ad6842b1a5292d4d8b32dc9c65c
 
-projects[i18n][version] = 1.17
+projects[i18n][version] = 1.15
 
 projects[i18nviews][version] = 3.0-alpha1
 projects[i18nviews][patch][] = https://www.drupal.org/files/issues/i18nviews-2245917-1-export-translatables-v1.patch

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -271,7 +271,7 @@ projects[job_scheduler][download][type] = git
 projects[job_scheduler][download][url] = https://git.drupal.org/project/job_scheduler.git
 projects[job_scheduler][download][revision] = 9baaba6bebd34ad6842b1a5292d4d8b32dc9c65c
 
-projects[i18n][version] = 1.15
+projects[i18n][version] = 1.17
 
 projects[i18nviews][version] = 3.0-alpha1
 projects[i18nviews][patch][] = https://www.drupal.org/files/issues/i18nviews-2245917-1-export-translatables-v1.patch

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -9,7 +9,7 @@ defaults[projects][subdir] = contrib
 projects[bat][type] = module
 projects[bat][download][type] = git
 projects[bat][download][url] = https://github.com/Roomify/bat_drupal.git
-projects[bat][download][tag] = 7.x-1.19
+projects[bat][download][tag] = 7.x-1.23
 projects[bat][subdir] = bat
 
 projects[bat_api][type] = module
@@ -607,14 +607,14 @@ libraries[fullcalendar][directory_name] = fullcalendar
 libraries[fullcalendar][type] = library
 libraries[fullcalendar][destination] = libraries
 libraries[fullcalendar][download][type] = get
-libraries[fullcalendar][download][url] = https://github.com/arshaw/fullcalendar/releases/download/v3.2.0/fullcalendar-3.2.0.zip
+libraries[fullcalendar][download][url] = https://github.com/arshaw/fullcalendar/releases/download/v3.4.0/fullcalendar-3.4.0.zip
 
 ; scheduler
 libraries[scheduler][directory_name] = fullcalendar-scheduler
 libraries[scheduler][type] = library
 libraries[scheduler][destination] = libraries
 libraries[scheduler][download][type] = get
-libraries[scheduler][download][url] = https://github.com/fullcalendar/fullcalendar-scheduler/releases/download/v1.5.1/fullcalendar-scheduler-1.5.1.zip
+libraries[scheduler][download][url] = https://github.com/fullcalendar/fullcalendar-scheduler/releases/download/v1.6.2/fullcalendar-scheduler-1.6.2.zip
 
 ; stripe-php
 libraries[stripe-php][download][type] = file

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -702,6 +702,8 @@ function roomify_accommodation_booking_confirmation_form($form, &$form_state, $s
     $form_state['storage']['group_size'] = check_plain($_GET['group_size']);
   }
 
+  $group_size = isset($form_state['storage']['group_size']) ? $form_state['storage']['group_size'] : 0;
+
   $total = $amount;
   $total_offer = $offer_amount;
 
@@ -711,24 +713,25 @@ function roomify_accommodation_booking_confirmation_form($form, &$form_state, $s
 
     if ($option['type'] == ROOMIFY_ACCOMMODATION_OPTIONS_MANDATORY) {
       $quantity = isset($form_state['values']['options'][$option_name . ':quantity']) ? $form_state['values']['options'][$option_name . ':quantity'] + 1 : 1;
-      $price = roomify_accommodation_options_get_option_price($amount / 100, $option, $quantity, $nights) * $quantity;
+
+      $price = roomify_accommodation_options_get_option_price($amount / 100, $option, $quantity, $nights, $group_size) * $quantity;
 
       $total += $price;
 
       if ($offer_amount > 0) {
-        $price = roomify_accommodation_options_get_option_price($offer_amount / 100, $option, $quantity, $nights) * $quantity;
+        $price = roomify_accommodation_options_get_option_price($offer_amount / 100, $option, $quantity, $nights, $group_size) * $quantity;
 
         $total_offer += $price;
       }
     }
     elseif (!empty($form_state['values']['options'][$option_name])) {
       $quantity = isset($form_state['values']['options'][$option_name . ':quantity']) ? $form_state['values']['options'][$option_name . ':quantity'] + 1 : 1;
-      $price = roomify_accommodation_options_get_option_price($amount / 100, $option, $quantity, $nights) * $quantity;
+      $price = roomify_accommodation_options_get_option_price($amount / 100, $option, $quantity, $nights, $group_size) * $quantity;
 
       $total += $price;
 
       if ($offer_amount > 0) {
-        $price = roomify_accommodation_options_get_option_price($offer_amount / 100, $option, $quantity, $nights) * $quantity;
+        $price = roomify_accommodation_options_get_option_price($offer_amount / 100, $option, $quantity, $nights, $group_size) * $quantity;
 
         $total_offer += $price;
       }
@@ -1114,6 +1117,8 @@ function roomify_accommodation_booking_confirmation_form_submit($form, &$form_st
 
   $values = $form_state['values'];
 
+  $group_size = isset($form_state['storage']['group_size']) ? $form_state['storage']['group_size'] : 0;
+
   $event_type = 'availability';
 
   $start_date = $values['start_date'];
@@ -1213,7 +1218,7 @@ function roomify_accommodation_booking_confirmation_form_submit($form, &$form_st
       // If the option is enabled:
       if (!empty($values['options'][$option_name])) {
         $quantity = isset($values['options'][$option_name . ':quantity']) ? $values['options'][$option_name . ':quantity'] + 1 : 1;
-        $price = roomify_accommodation_options_get_option_price($amount / 100, $option, $quantity, $values['nights']);
+        $price = roomify_accommodation_options_get_option_price($amount / 100, $option, $quantity, $values['nights'], $group_size);
 
         // Create the new line item.
         $option_line_item = entity_create('commerce_line_item', array(

--- a/modules/roomify/roomify_accommodation_options/roomify_accommodation_options.module
+++ b/modules/roomify/roomify_accommodation_options/roomify_accommodation_options.module
@@ -8,6 +8,10 @@ define('ROOMIFY_ACCOMMODATION_OPTIONS_ADD', 'add');
 define('ROOMIFY_ACCOMMODATION_OPTIONS_ADD_DAILY', 'add-daily');
 define('ROOMIFY_ACCOMMODATION_OPTIONS_SUB', 'sub');
 define('ROOMIFY_ACCOMMODATION_OPTIONS_SUB_DAILY', 'sub-daily');
+define('ROOMIFY_ACCOMMODATION_OPTIONS_ADD_PERSON', 'add_person');
+define('ROOMIFY_ACCOMMODATION_OPTIONS_ADD_DAILY_PERSON', 'add-daily_person');
+define('ROOMIFY_ACCOMMODATION_OPTIONS_SUB_PERSON', 'sub_person');
+define('ROOMIFY_ACCOMMODATION_OPTIONS_SUB_DAILY_PERSON', 'sub-daily_person');
 define('ROOMIFY_ACCOMMODATION_OPTIONS_REPLACE', 'replace');
 define('ROOMIFY_ACCOMMODATION_OPTIONS_INCREASE', 'increase');
 define('ROOMIFY_ACCOMMODATION_OPTIONS_DECREASE', 'decrease');
@@ -246,7 +250,7 @@ function roomify_accommodation_options_field_widget_form(&$form, &$form_state, $
       '#title' => t('Value'),
       '#size' => 10,
       '#default_value' => isset($items[$delta]['value']) ? $items[$delta]['value'] : NULL,
-      '#element_validate' => array('element_validate_integer_positive'),
+      '#element_validate' => array('roomify_accommodation_options_element_value_validate'),
       '#attributes' => array(
         'class' => array('roomify_accommodation_options-option--value'),
       ),
@@ -286,6 +290,17 @@ function roomify_accommodation_options_field_widget_form(&$form, &$form_state, $
     $element['#attached']['css'] = array(drupal_get_path('module', 'roomify_accommodation_options') . '/css/roomify_accommodation_options_widget.css');
 
     return $element;
+  }
+}
+
+/**
+ * Form element validation handler for numeric elements that must be positive.
+ */
+function roomify_accommodation_options_element_value_validate($element, &$form_state) {
+  $value = $element['#value'];
+
+  if ($value != '' && (!is_numeric($value) || $value <= 0)) {
+    form_error($element, t('%name must be a positive number.', array('%name' => $element['#title'])));
   }
 }
 
@@ -416,6 +431,10 @@ function roomify_accommodation_options_price_options() {
     ROOMIFY_ACCOMMODATION_OPTIONS_ADD_DAILY => t('Add to price per night'),
     ROOMIFY_ACCOMMODATION_OPTIONS_SUB => t('Subtract from price'),
     ROOMIFY_ACCOMMODATION_OPTIONS_SUB_DAILY => t('Subtract from price per night'),
+    ROOMIFY_ACCOMMODATION_OPTIONS_ADD_PERSON => t('Add to price per person'),
+    ROOMIFY_ACCOMMODATION_OPTIONS_ADD_DAILY_PERSON => t('Add to price per night per person'),
+    ROOMIFY_ACCOMMODATION_OPTIONS_SUB_PERSON => t('Subtract from price per person'),
+    ROOMIFY_ACCOMMODATION_OPTIONS_SUB_DAILY_PERSON => t('Subtract from price per night per person'),
     ROOMIFY_ACCOMMODATION_OPTIONS_REPLACE => t('Replace price'),
     ROOMIFY_ACCOMMODATION_OPTIONS_INCREASE => t('Increase price by % amount'),
     ROOMIFY_ACCOMMODATION_OPTIONS_DECREASE => t('Decrease price by % amount'),
@@ -550,6 +569,34 @@ function roomify_accommodation_options_get_operation_label($option) {
         '@currency_symbol' => $currency_symbol,
       ));
       break;
+
+    case 'add_person':
+      $label = t('+@amount@currency_symbol per person to price', array(
+        '@amount' => $option['value'],
+        '@currency_symbol' => $currency_symbol,
+      ));
+      break;
+
+    case 'add-daily_person':
+      $label = t('+@amount@currency_symbol per night per person to price', array(
+        '@amount' => $option['value'],
+        '@currency_symbol' => $currency_symbol,
+      ));
+      break;
+
+    case 'sub_person':
+      $label = t('-@amount@currency_symbol per person from price', array(
+        '@amount' => $option['value'],
+        '@currency_symbol' => $currency_symbol,
+      ));
+      break;
+
+    case 'sub-daily_person':
+      $label = t('-@amount@currency_symbol per night per person from price', array(
+        '@amount' => $option['value'],
+        '@currency_symbol' => $currency_symbol,
+      ));
+      break;
   }
 
   return $label;
@@ -557,8 +604,16 @@ function roomify_accommodation_options_get_operation_label($option) {
 
 /**
  * Calculate the price for an option.
+ *
+ * @param $booking_price
+ * @param $option
+ * @param $quantity
+ * @param $nights
+ * @param $persons
+ *
+ * @return float
  */
-function roomify_accommodation_options_get_option_price($booking_price, $option, $quantity, $nights) {
+function roomify_accommodation_options_get_option_price($booking_price, $option, $quantity, $nights, $persons = 0) {
   $price = 0;
 
   switch ($option['operation']) {
@@ -590,6 +645,22 @@ function roomify_accommodation_options_get_option_price($booking_price, $option,
 
     case ROOMIFY_ACCOMMODATION_OPTIONS_DECREASE:
       $price -= $booking_price * $option['value'] / 100;
+      break;
+
+    case ROOMIFY_ACCOMMODATION_OPTIONS_ADD_PERSON:
+      $price += $option['value'] * $persons;
+      break;
+
+    case ROOMIFY_ACCOMMODATION_OPTIONS_ADD_DAILY_PERSON:
+      $price += $option['value'] * $nights * $persons;
+      break;
+
+    case ROOMIFY_ACCOMMODATION_OPTIONS_SUB_PERSON:
+      $price -= $option['value'] * $persons;
+      break;
+
+    case ROOMIFY_ACCOMMODATION_OPTIONS_SUB_DAILY_PERSON:
+      $price -= $option['value'] * $nights * $persons;
       break;
   }
 

--- a/modules/roomify/roomify_conversations/roomify_conversations.module
+++ b/modules/roomify/roomify_conversations/roomify_conversations.module
@@ -1855,3 +1855,28 @@ function roomify_conversations_inquiry_render($conversation) {
 
   return $output;
 }
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function roomify_conversations_query_roomify_conversation_access_alter(QueryAlterableInterface $query) {
+  // Look for an event base table to pass to the query altering function or
+  // else assume we don't have the tables we need to establish order related
+  // altering right now.
+  foreach ($query->getTables() as $table) {
+    if ($table['table'] === 'roomify_conversations') {
+      $query->leftJoin('field_data_conversation_owner_user_ref', 'user_ref', 'roomify_conversations.conversation_id = user_ref.entity_id');
+
+      bat_entity_access_query_alter($query, 'roomify_conversation', $table['alias']);
+
+      break;
+    }
+  }
+}
+
+/**
+ * Implements hook_bat_entity_access_view_condition_roomify_conversation_alter().
+ */
+function roomify_conversations_bat_entity_access_view_condition_roomify_conversation_alter(&$conditions, $context) {
+  $conditions->condition('user_ref.conversation_owner_user_ref_target_id', $context['account']->uid);
+}

--- a/modules/roomify/roomify_conversations/roomify_conversations.pages_default.inc
+++ b/modules/roomify/roomify_conversations/roomify_conversations.pages_default.inc
@@ -19,11 +19,12 @@ function roomify_conversations_default_page_manager_pages() {
   $page->access = array(
     'plugins' => array(
       0 => array(
-        'name' => 'perm',
+        'name' => 'php',
         'settings' => array(
-          'perm' => 'view own roomify_conversation entities',
+          'description' => '',
+          'php' => '$conversation = $contexts[\'argument_entity_id:roomify_conversation_1\']->data;
+  return roomify_conversation_access(\'view\', $conversation);',
         ),
-        'context' => 'logged-in-user',
         'not' => FALSE,
       ),
     ),
@@ -76,6 +77,8 @@ function roomify_conversations_default_page_manager_pages() {
   $display->cache = array();
   $display->title = 'Conversation %roomify_conversation:conversation-id';
   $display->uuid = '9f5a56b0-08e8-4ad2-8e77-cea38515974d';
+  $display->storage_type = 'page_manager';
+  $display->storage_id = 'page_conversation__panel';
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -324,7 +324,7 @@ function roomify_dashboard_page_alter(&$page) {
         }
       }
 
-      $info_icon = '<img src="' . url(drupal_get_path('module', 'roomify_dashboard') . '/images/info.png') . '">';
+      $info_icon = '<img src="' . file_create_url(drupal_get_path('module', 'roomify_dashboard') . '/images/info.png') . '">';
       $page['content']['help']['content']['#markup'] = '<a target="_blank" href="' . $link . '"><div class="help-icon"><span>' . t('Documentation') . '</span>' . $info_icon . '</div></a>';
     }
   }
@@ -378,7 +378,7 @@ function roomify_dashboard_menu_link_alter(&$item) {
     $item['menu_token_enabled'] = 1;
     if (isset($item['language']) && $item['language'] != 'en' && $item['language'] != LANGUAGE_NONE) {
       // Check if the original link has a class.
-      if ($translations = $item['translation_set']->get_translations()) {
+      if ((isset($item['translation_set'])) && ($translations = $item['translation_set']->get_translations())) {
         $class = isset($translations['en']['options']['attributes']['class']) ? $translations['en']['options']['attributes']['class'] : '';
         $item['options']['attributes']['class'] = $class;
       }

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.views_default.inc
@@ -2869,7 +2869,8 @@ function roomify_dashboard_views_default_views() {
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['title'] = 'Contact Form Submissions';
   $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['access']['perm'] = 'view any entityform';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'basic';

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -382,6 +382,20 @@ function roomify_listing_entity_update($entity, $type) {
   if ($type == 'bat_type') {
     if ($entity->type == 'home' || $entity->type == 'room') {
       roomify_listing_update_rates($entity);
+
+      // Set the type with the maximum capacity to have the
+      // right number on the availability search filter.
+      if ($max_capacity = field_get_items('bat_type', $entity, 'field_st_max_capacity')) {
+        $max_properties_capacity = variable_get('roomify_max_property_type_capacity', '1');
+        if ($max_capacity[0]['value'] >= $max_properties_capacity) {
+          variable_set('roomify_max_property_type_capacity', $max_capacity[0]['value']);
+        }
+      }
+    }
+
+    // Re-index the Property after changes to the type.
+    if (module_exists('search_api') && isset($entity->field_st_property_reference[LANGUAGE_NONE][0]['target_id'])) {
+      search_api_track_item_change('roomify_property', array($entity->field_st_property_reference[LANGUAGE_NONE][0]['target_id']));
     }
   }
 }

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -279,17 +279,6 @@ function roomify_listing_field_collection_item_delete(FieldCollectionItemEntity 
  * Implements hook_entity_insert().
  */
 function roomify_listing_entity_insert($entity, $type) {
-  global $user;
-
-  if ($type == 'roomify_property' && $entity->type == 'standard_property') {
-    if (!isset($entity->field_sp_owner[LANGUAGE_NONE][0]['target_id'])) {
-      $entity->field_sp_owner[LANGUAGE_NONE][0]['target_id'] = $user->uid;
-      field_attach_update($type, $entity);
-    }
-
-    roomify_listing_edit_property_tax($entity);
-  }
-
   if ($type == 'bat_type') {
     if ($entity->type == 'home' || $entity->type == 'room') {
       roomify_listing_update_rates($entity);
@@ -305,8 +294,25 @@ function roomify_listing_entity_presave($entity, $type) {
 
   if ($type == 'roomify_property') {
     if ($entity->type == 'casa_property' || $entity->type == 'locanda_property') {
+      $types_reference = field_get_items($type, $entity, 'property_bat_type_reference');
+
       if (isset($entity->is_new) && $entity->is_new) {
         $entity->field_sp_manager[LANGUAGE_NONE][0]['target_id'] = $entity->uid;
+
+        if (empty($types_reference)) {
+          $bat_type = bat_type_create(
+            array(
+              'name' => $entity->name,
+              'type' => ($entity->type == 'casa_property') ? 'home' : 'room',
+              'uid' => $user->uid,
+              'created' => REQUEST_TIME,
+            )
+          );
+
+          $bat_type->save();
+
+          $entity->property_bat_type_reference[LANGUAGE_NONE][0]['target_id'] = $bat_type->type_id;
+        }
       }
       else {
         if (!isset($entity->field_sp_owner[LANGUAGE_NONE][0]['target_id'])) {
@@ -316,7 +322,7 @@ function roomify_listing_entity_presave($entity, $type) {
     }
 
     if ($entity->type == 'casa_property') {
-      foreach ($entity->property_bat_type_reference[LANGUAGE_NONE] as $type) {
+      foreach ($types_reference as $type) {
         if ($bat_type = bat_type_load($type['target_id'])) {
           $bat_type->name = $entity->name;
           $bat_type->save();

--- a/modules/roomify/roomify_offers/roomify_offers.module
+++ b/modules/roomify/roomify_offers/roomify_offers.module
@@ -39,9 +39,10 @@ function roomify_offers_menu() {
     'weight' => 2,
   );
 
-  $items['admin/bat/config/global/offers/add'] = array(
+  $items['admin/bat/config/global/offers/add/%ctools_js'] = array(
     'title' => 'Add Offer',
     'page callback' => 'roomify_offers_add_offer_page',
+    'page arguments' => array(6),
     'access arguments' => array('administer offers'),
   );
 
@@ -263,7 +264,7 @@ function roomify_offers_preprocess_offers_pricing_calendar(&$vars) {
 function roomify_offers_manage_page() {
   roomify_dashboard_setup_modal();
 
-  $button_add = l(t('add special offer'), 'admin/bat/config/global/offers/add', array('attributes' => array('class' => 'add-offer-button ctools-use-modal ctools-modal-roomify-dashboard-modal-style')));
+  $button_add = l(t('add special offer'), 'admin/bat/config/global/offers/add/ajax', array('attributes' => array('class' => 'add-offer-button ctools-use-modal ctools-modal-roomify-dashboard-modal-style')));
 
   $view = views_embed_view('special_offers', 'block_1');
 
@@ -273,28 +274,33 @@ function roomify_offers_manage_page() {
 /**
  * Add new offer modal page.
  */
-function roomify_offers_add_offer_page() {
-  ctools_include('ajax');
-  ctools_include('modal');
+function roomify_offers_add_offer_page($js = NULL) {
+  if ($js) {
+    ctools_include('ajax');
+    ctools_include('modal');
 
-  $form_state = array(
-    'ajax' => TRUE,
-    'title' => t('Add New Special Offer'),
-  );
+    $form_state = array(
+      'ajax' => TRUE,
+      'title' => t('Add New Special Offer'),
+    );
 
-  // Use ctools to generate ajax instructions for the browser to create
-  // a form in a modal popup.
-  $output = ctools_modal_form_wrapper('roomify_offers_add_offer_form', $form_state);
+    // Use ctools to generate ajax instructions for the browser to create
+    // a form in a modal popup.
+    $output = ctools_modal_form_wrapper('roomify_offers_add_offer_form', $form_state);
 
-  // If the form has been submitted, there may be additional instructions
-  // such as dismissing the modal popup.
-  if (!empty($form_state['ajax_commands'])) {
-    $output = $form_state['ajax_commands'];
+    // If the form has been submitted, there may be additional instructions
+    // such as dismissing the modal popup.
+    if (!empty($form_state['ajax_commands'])) {
+      $output = $form_state['ajax_commands'];
+    }
+
+    // Return the ajax instructions to the browser via ajax_render().
+    print ajax_render($output);
+    drupal_exit();
   }
-
-  // Return the ajax instructions to the browser via ajax_render().
-  print ajax_render($output);
-  drupal_exit();
+  else {
+    return drupal_get_form('roomify_offers_add_offer_form');
+  }
 }
 
 /**
@@ -390,9 +396,16 @@ function roomify_offers_add_offer_form_submit($form, &$form_state) {
 
   $rate->save();
 
-  ctools_add_js('ajax-responder');
-  $form_state['ajax_commands'][] = ctools_modal_command_dismiss();
-  $form_state['ajax_commands'][] = ctools_ajax_command_redirect('admin/bat/config/global/offers');
+  if (isset($form_state['ajax']) && $form_state['ajax']) {
+    ctools_add_js('ajax-responder');
+    $form_state['ajax_commands'][] = ctools_modal_command_dismiss();
+    $form_state['ajax_commands'][] = ctools_ajax_command_redirect('admin/bat/config/global/offers');
+  }
+  else {
+    drupal_set_message(t('Offer created'));
+
+    $form_state['redirect'] = 'admin/bat/config/global/offers';
+  }
 }
 
 /**

--- a/modules/roomify/roomify_pages_manager/roomify_pages_manager.module
+++ b/modules/roomify/roomify_pages_manager/roomify_pages_manager.module
@@ -30,6 +30,8 @@ function roomify_pages_manager_ctools_render_alter(&$info, $page, $context) {
             $entity = $context_argument->data;
             $entity_type = str_replace('entity:', '', $context_argument->plugin);
 
+            drupal_set_title($entity->name);
+
             // Verify this is an appropriate entity.
             $entity_info = entity_get_info($entity_type);
             if (!empty($entity_info) && _metatag_entity_is_page($entity_type, $entity)) {

--- a/modules/roomify/roomify_system/roomify_system.install
+++ b/modules/roomify/roomify_system/roomify_system.install
@@ -664,3 +664,10 @@ function roomify_system_update_7039() {
 function roomify_system_update_7040() {
   module_enable(array('profile2_page'));
 }
+
+/**
+ * Let users access with email.
+ */
+function roomify_system_update_7041() {
+  variable_set('logintoboggan_login_with_email', '1');
+}

--- a/modules/roomify/roomify_translate/roomify_translate.module
+++ b/modules/roomify/roomify_translate/roomify_translate.module
@@ -82,6 +82,12 @@ function roomify_translate_module_implements_alter(&$implementations, $hook) {
     unset($implementations['roomify_translate']);
     $implementations['roomify_translate'] = $group;
   }
+
+  if ($hook == 'translated_menu_link_alter' && isset($implementations['roomify_translate'])) {
+    $group = $implementations['roomify_translate'];
+    unset($implementations['roomify_translate']);
+    $implementations['roomify_translate'] = $group;
+  }
 }
 
 /**
@@ -164,6 +170,30 @@ function roomify_translate_entity_presave($entity, $type) {
   if ($type == 'taxonomy_term') {
     if (!isset($entity->language)) {
       $entity->language = language_default('language');
+    }
+  }
+}
+
+/**
+ * Implements hook_translated_menu_link_alter().
+ *
+ * @see i18n_menu_translated_menu_link_alter()
+ */
+function roomify_translate_translated_menu_link_alter(&$item) {
+  if ($item['menu_name'] == 'roomify_dashboard_menu') {
+    if (!_i18n_menu_link_is_visible($item)) {
+      if ($item['i18n_tsid']) {
+        $translation_set = i18n_translation_set_load($item['i18n_tsid']);
+        $translations = $translation_set->get_translations();
+
+        if ($item['hidden'] && count($translations) == 1) {
+          $item['hidden'] = FALSE;
+        }
+      }
+
+      if ($item['hidden'] && $item['i18n_tsid'] == '0') {
+        $item['hidden'] = FALSE;
+      }
     }
   }
 }

--- a/roomify.install
+++ b/roomify.install
@@ -311,6 +311,8 @@ function roomify_install_finished(&$install_state) {
 
   variable_set('mimemail_format', 'rich_text');
 
+  variable_set('logintoboggan_login_with_email', '1');
+
   // AddToAny Variables
   variable_set('addtoany_buttons_size', '25');
   variable_set('addtoany_additional_html', '<a class="a2a_button_facebook"></a>

--- a/test/behat/features/02_addons.feature
+++ b/test/behat/features/02_addons.feature
@@ -10,7 +10,7 @@ Feature: Add-ons
     And I fill in "field_addons[en][0][value]" with "50"
     Then I press "Save Type"
 
-    Then I visit "booking/2017-05-02/2017-05-05/2"
+    Then I visit "booking/2017-09-02/2017-09-05/2"
     And I should see "$45.00" in the "#roomify-accommodation-booking-confirmation-form td.price" element
     And I check "options[decrease_price_by_percentage_amount]"
     And I wait for AJAX to finish
@@ -25,7 +25,7 @@ Feature: Add-ons
     And I fill in "field_addons[en][0][value]" with "50"
     Then I press "Save Type"
 
-    Then I visit "booking/2017-05-02/2017-05-05/2"
+    Then I visit "booking/2017-09-02/2017-09-05/2"
     And I should see "$45.00" in the "#roomify-accommodation-booking-confirmation-form td.price" element
     And I check "options[increase_price_by_percentage_amount]"
     And I wait for AJAX to finish

--- a/test/behat/features/12_offers.feature
+++ b/test/behat/features/12_offers.feature
@@ -22,7 +22,7 @@ Feature: Special offers
 
     Then I visit "admin/bat/config/global/offers/calendar"
     And I wait 10 seconds
-    Then I select dates between "2017-05-01" and "2017-05-28" for the last rate
+    Then I select dates between "2017-08-01" and "2017-08-28" for the last rate
     And I wait 10 seconds
     Then I fill in "pricing_event_price[und][0][amount]" with "5"
     And I press "Update value"
@@ -31,7 +31,7 @@ Feature: Special offers
     Then I visit "admin/bat/config/property/manage/1/offers"
     And I click on "Participate" on the row containing "Flat offer"
 
-    Then I visit "booking/2017-05-02/2017-05-05/1"
+    Then I visit "booking/2017-08-02/2017-08-05/1"
     And I should see "$15.00" in the ".current-search-item.current-search-price .offer-cost" element
     And I should see "$15.00" in the "#roomify-accommodation-booking-confirmation-form .price .offer-cost" element
 

--- a/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
+++ b/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
@@ -1615,6 +1615,9 @@ body.adminimal-theme .cke_reset_all label {
   width: 100%;
   margin: 5px 0;
 }
+form[id^=roomify-property-wizard-form] h2,
+#roomify-property-wizard-form h2,
+form[id^=roomify-property-wizard-form] .form-item-property-name,
 #roomify-property-wizard-form .form-item-property-name {
   margin-bottom: 20px;
 }
@@ -2024,6 +2027,9 @@ body .ui-dialog .ui-button-text {
 }
 .pane-properties-dashboard-properties .view-display-id-dashboard_properties td.views-field-name .property-info .property-changed .label {
   font-weight: 600;
+}
+.pane-properties-dashboard-properties .view-display-id-dashboard_properties td.views-field a {
+  color: #5a5a5a;
 }
 .pane-properties-dashboard-properties .view-display-id-dashboard_properties td.views-field.views-field-edit-unit {
   width: 30px;
@@ -2737,6 +2743,9 @@ body.adminimal-skin-material table.views-table tbody tr td {
 #bat-booking-edit-ical-form fieldset#edit-order .view-order,
 #bat-booking-edit-booking-com-form fieldset#edit-order .view-order {
   font-size: 120%;
+}
+.page-admin-bat-config-property .form-type-textfield.form-item-name input {
+  font-size: 20px;
 }
 @media (max-width: 768px) {
   .page-admin-bat-config-property #calendar.field-name-booking-full-name {
@@ -3516,6 +3525,14 @@ a.ctools-use-modal:hover,
     padding-top: 15px;
     width: 80% !important;
   }
+}
+div.ctools-modal-content .modal-content {
+  padding: 1em;
+}
+div.ctools-modal-content div.type-container .container-inline .form-item input[name*=price],
+div.ctools-modal-content div.type-container .container-inline .form-item input[name*=rooms],
+div.ctools-modal-content div.type-container .container-inline .form-item input[name*=occupancy] {
+  width: 5em;
 }
 #references-dialog-page .view-customer-profiles td {
   cursor: pointer;

--- a/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
+++ b/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
@@ -2092,11 +2092,14 @@ body .ui-dialog .ui-button-text {
   box-shadow: none;
   display: block;
   border: none;
-  padding-top: 10px;
   border-top: none !important;
 }
-.page-admin-bat-config-types-manage #main-content .vertical-tabs-panes fieldset legend,
-.page-admin-bat-config-property-manage #main-content .vertical-tabs-panes fieldset legend {
+.page-admin-bat-config-types-manage #main-content .vertical-tabs-panes > fieldset,
+.page-admin-bat-config-property-manage #main-content .vertical-tabs-panes > fieldset {
+  padding-top: 10px;
+}
+.page-admin-bat-config-types-manage #main-content .vertical-tabs-panes > fieldset > legend,
+.page-admin-bat-config-property-manage #main-content .vertical-tabs-panes > fieldset > legend {
   display: none !important;
 }
 .page-admin-bat-config-types-manage .field-name-field-sp-gallery .property-gallery-show-text,
@@ -3522,9 +3525,6 @@ a.ctools-use-modal:hover,
 }
 .manualcrop-style-button-holder input {
   background: #FF9800 !important;
-}
-.vertical-tabs-panes fieldset fieldset .fieldset-legend {
-  display: none;
 }
 .roomify-property-reviewed {
   display: inline-block;

--- a/themes/roomify/roomify_adminimal_theme/less/components/bat_booking.less
+++ b/themes/roomify/roomify_adminimal_theme/less/components/bat_booking.less
@@ -55,6 +55,9 @@
 
 
 .page-admin-bat-config-property {
+  .form-type-textfield.form-item-name input {
+    font-size: 20px;
+  }
   #calendar.field-name-booking-full-name, {
     @media (max-width: @screen-sm) {
       margin-top: 40px;

--- a/themes/roomify/roomify_adminimal_theme/less/components/modal.less
+++ b/themes/roomify/roomify_adminimal_theme/less/components/modal.less
@@ -1,29 +1,31 @@
 #modalContent div.ctools-modal-content {
   .form-item label {
-	  font-size: 15px;
-	  font-weight: 400;
-	}
-	h2 {
-		font-size: 28px;
-		font-weight: 400;
-	}
+    font-size: 15px;
+    font-weight: 400;
+  }
+  h2 {
+    font-size: 28px;
+    font-weight: 400;
+  }
 }
 #modalContent {
-	#edit-container {
-		padding-left: 0;
-	}
-	.form-item-max-occupants,
-	.form-item-default-price {
-		display: inline-block;
-		width: 100%;
-		margin: 5px 0;
-	}
+  #edit-container {
+    padding-left: 0;
+  }
+  .form-item-max-occupants,
+  .form-item-default-price {
+    display: inline-block;
+    width: 100%;
+    margin: 5px 0;
+  }
 }
 
+form[id^=roomify-property-wizard-form],
 #roomify-property-wizard-form {
-	.form-item-property-name {
-		margin-bottom: 20px;
-	}
+  h2,
+  .form-item-property-name {
+    margin-bottom: 20px;
+  }
 }
 
 /* Override bat modal close button styling. */
@@ -59,18 +61,18 @@
 
 
 body .ui-dialog {
-	.ui-widget-header {
-		background: #405467;
-	}
-	.ui-dialog-title {
+  .ui-widget-header {
+    background: #405467;
+  }
+  .ui-dialog-title {
     font-size: 20px;
     font-weight: 400;
     margin: 5px 0;
-	}
-	.ui-dialog-content {
-		padding: 30px 10px;
-	}
-	.ui-button-text {
-		padding: 5px 10px;
-	}
+  }
+  .ui-dialog-content {
+    padding: 30px 10px;
+  }
+  .ui-button-text {
+    padding: 5px 10px;
+  }
 }

--- a/themes/roomify/roomify_adminimal_theme/less/components/properties.less
+++ b/themes/roomify/roomify_adminimal_theme/less/components/properties.less
@@ -306,6 +306,9 @@
       }
     }
     td.views-field {
+      a {
+        color: #5a5a5a;
+      }
       &.views-field-edit-unit {
         width: 30px;
         a {

--- a/themes/roomify/roomify_adminimal_theme/less/components/properties.less
+++ b/themes/roomify/roomify_adminimal_theme/less/components/properties.less
@@ -387,9 +387,11 @@
         box-shadow: none;
         display: block;
         border: none;
-        padding-top: 10px;
         border-top: none !important;
-        legend {
+      }
+      > fieldset {
+        padding-top: 10px;
+        > legend {
           display: none !important;
         }
       }

--- a/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
+++ b/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
@@ -226,6 +226,14 @@ a.ctools-use-modal,
     }
   }
 }
+div.ctools-modal-content .modal-content {
+  padding: 1em;
+}
+div.ctools-modal-content div.type-container .container-inline .form-item input[name*=price],
+div.ctools-modal-content div.type-container .container-inline .form-item input[name*=rooms],
+div.ctools-modal-content div.type-container .container-inline .form-item input[name*=occupancy] {
+  width: 5em;
+}
 
 #references-dialog-page .view-customer-profiles td {
   cursor: pointer;

--- a/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
+++ b/themes/roomify/roomify_adminimal_theme/less/roomify_adminimal_theme.less
@@ -237,12 +237,6 @@ a.ctools-use-modal,
   }
 }
 
-.vertical-tabs-panes fieldset fieldset {
-  .fieldset-legend {
-    display: none;
-  }
-}
-
 .roomify-property-reviewed {
   display: inline-block;
   width: 100%;
@@ -263,5 +257,6 @@ a.ctools-use-modal,
   h1 {
     margin-top: 48px;
     font-weight: 400;
+    font-style: italic;
   }
 }

--- a/themes/roomify/roomify_travel/color/preview.css
+++ b/themes/roomify/roomify_travel/color/preview.css
@@ -1,6 +1,6 @@
 #preview #header,
 #preview #footer {
-  height: 50px;
+  height: 66px;
   width: 800px;
   display: inline-block;
   padding: 8px 16px;


### PR DESCRIPTION
A roomify manager should be able to define an add-on for Types with a price/night/person. The perfect exemple is the tourism tax that you can found in France (maybe in some other countries).

<img width="880" alt="capture d ecran 2017-04-12 a 10 26 06" src="https://cloud.githubusercontent.com/assets/23718178/24948445/a1c5b214-1f6a-11e7-9eb9-d02059292d49.png">

You will find attached an experimental implementation of this new add-on.
[Archive.zip](https://github.com/Roomify/RfA/files/915893/Archive.zip)
