### PR TITLE
PET additional options do not work

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -361,8 +361,11 @@ projects[pathauto][version] = 1.3
 
 projects[pathauto_entity][version] = 1.0
 
-projects[pet][version] = 1.0-rc1
-projects[pet][patch][] = https://www.drupal.org/files/pet-add-rules-state-2092195-1.patch
+projects[pet][type] = module
+projects[pet][download][type] = git
+projects[pet][download][url] = https://git.drupal.org/project/pet.git
+projects[pet][download][revision] = 3a42221335ecf717a6a538e431394afcd7f198c3
+projects[pet][patch][] = https://www.drupal.org/files/issues/add-rule-state-and-allow-from-override-2879713-1.patch
 projects[pet][patch][] = https://www.drupal.org/files/issues/pet-specify_entity_types_for_tokens-2612754-1.patch
 projects[pet][patch][] = https://www.drupal.org/files/issues/multilanguage-support-2727733-6.patch
 

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -1436,19 +1436,6 @@ function roomify_listing_enquiry_form_submit($form, &$form_state) {
 
   $to_account = user_load($type->uid);
 
-  $pet = pet_load('new_booking_enquiry');
-  $pet_options = array();
-
-  if (isset($pet->from_override)) {
-    $pet_options['pet_from'] = $pet->from_override;
-  }
-  if (isset($pet->cc_default)) {
-    $pet_options['pet_cc'] = explode(',', $pet->cc_default);
-  }
-  if (isset($pet->bcc_default)) {
-    $pet_options['pet_bcc'] = explode(',', $pet->bcc_default);
-  }
-
   pet_action_send_pet('new_booking_enquiry', NULL, $to_account, NULL, NULL, $pet_options, $rules_state);
 
   $commands = array();

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -1435,7 +1435,21 @@ function roomify_listing_enquiry_form_submit($form, &$form_state) {
   $rules_state->variables['roomify_conversation'] = $conversation_wrapper;
 
   $to_account = user_load($type->uid);
-  pet_action_send_pet('new_booking_enquiry', NULL, $to_account, NULL, NULL, array(), $rules_state);
+
+  $pet = pet_load('new_booking_enquiry');
+  $pet_options = array();
+
+  if (isset($pet->from_override)) {
+    $pet_options['pet_from'] = $pet->from_override;
+  }
+  if (isset($pet->cc_default)) {
+    $pet_options['pet_cc'] = explode(',', $pet->cc_default);
+  }
+  if (isset($pet->bcc_default)) {
+    $pet_options['pet_bcc'] = explode(',', $pet->bcc_default);
+  }
+
+  pet_action_send_pet('new_booking_enquiry', NULL, $to_account, NULL, NULL, $pet_options, $rules_state);
 
   $commands = array();
   $commands[] = ctools_modal_command_dismiss();

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -1436,7 +1436,7 @@ function roomify_listing_enquiry_form_submit($form, &$form_state) {
 
   $to_account = user_load($type->uid);
 
-  pet_action_send_pet('new_booking_enquiry', NULL, $to_account, NULL, NULL, $pet_options, $rules_state);
+  pet_action_send_pet('new_booking_enquiry', NULL, $to_account, NULL, NULL, array(), $rules_state);
 
   $commands = array();
   $commands[] = ctools_modal_command_dismiss();


### PR DESCRIPTION
Hello,
I've noticed that when editing PET email templates, and editing "additional options", those do not get applied.
For example, when you go to admin/structure/pets/manage/new_booking_enquiry and change "From override" to another email address, email still gets sent from default site address.  Same when adding a BCC field, etc.
