### PR TITLE
Featured Areas error 

### DIFF
--- a/modules/roomify/roomify_dashboard/roomify_dashboard.install
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.install
@@ -58,3 +58,29 @@ function roomify_dashboard_update_7006() {
   $accounts_mlid = roomify_system_get_menu_link_id('Accounts', 'user', 'roomify_dashboard_menu', -5);
   roomify_system_create_update_menu_link_with_token('My Users', 'user/[current-user:uid]/subuser', 'roomify_dashboard_menu', 11, 1, $accounts_mlid, array());
 }
+
+/**
+ * Fix path of the menu link "Featured Areas".
+ */
+function roomify_dashboard_update_7007() {
+  $featured_areas_subqueue_id = db_select('entityqueue_subqueue', 'e')
+    ->fields('e', array('subqueue_id'))
+    ->condition('queue', 'featured_areas')
+    ->execute()
+    ->fetchField();
+  if ($featured_areas_subqueue_id === FALSE) {
+    $featured_areas_subqueue_id = 2;
+  }
+
+  $mlid = db_select('menu_links', 'ml')
+    ->fields('ml', array('mlid'))
+    ->condition('ml.menu_name', 'roomify_dashboard_menu')
+    ->condition('link_path', 'admin/structure/entityqueue/list/featured_properties/subqueues/' . $featured_areas_subqueue_id . '/edit')
+    ->execute()
+    ->fetchField();
+
+  if ($menu = menu_link_load($mlid)) {
+    $menu['link_path'] = 'admin/structure/entityqueue/list/featured_areas/subqueues/' . $featured_areas_subqueue_id . '/edit';
+    menu_link_save($menu);
+  }
+}

--- a/modules/roomify/roomify_dashboard/roomify_dashboard.module
+++ b/modules/roomify/roomify_dashboard/roomify_dashboard.module
@@ -473,7 +473,7 @@ function roomify_dashboard_create_dashboard_menu() {
     $featured_areas_subqueue_id = 2;
   }
 
-  roomify_system_create_update_menu_link('Featured Areas', 'admin/structure/entityqueue/list/featured_properties/subqueues/' . $featured_areas_subqueue_id . '/edit', 'roomify_dashboard_menu', 4, 1, $content_mlid);
+  roomify_system_create_update_menu_link('Featured Areas', 'admin/structure/entityqueue/list/featured_areas/subqueues/' . $featured_areas_subqueue_id . '/edit', 'roomify_dashboard_menu', 4, 1, $content_mlid);
 
   roomify_system_create_update_menu_link('Main Menu', 'admin/structure/menu/manage/main-menu', 'roomify_dashboard_menu', 5, 1, $content_mlid);
   roomify_system_create_update_menu_link('Dashboard Menu', 'admin/structure/menu/manage/roomify_dashboard_menu', 'roomify_dashboard_menu', 6, 1, $content_mlid);


### PR DESCRIPTION
Hello,
Just wanted to report that when going to edit featured areas using the right sidebar menu (in the new updated 3.9 version) user is taken to link : /admin/structure/entityqueue/list/**featured_properties**/subqueues/2/edit?destination=user
At first areas show, but upon adding and saving, list becomes empty when returning to the same page, and it wants to pull properties not areas.  
After this when visiting admin/structure/entityqueue item lists are empty 
Ella
