### PR TITLE
Improve display of Casa properties on unified availability calendar

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -9,13 +9,13 @@ defaults[projects][subdir] = contrib
 projects[bat][type] = module
 projects[bat][download][type] = git
 projects[bat][download][url] = https://github.com/Roomify/bat_drupal.git
-projects[bat][download][tag] = 7.x-1.27
+projects[bat][download][tag] = 7.x-1.28
 projects[bat][subdir] = bat
 
 projects[bat_api][type] = module
 projects[bat_api][download][type] = git
 projects[bat_api][download][url] = https://github.com/Roomify/bat_api.git
-projects[bat_api][download][tag] = 7.x-2.6
+projects[bat_api][download][tag] = 7.x-2.7
 projects[bat_api][subdir] = bat
 
 projects[bat_event_state_constraints][type] = module
@@ -34,7 +34,7 @@ projects[roomify_rate][subdir] = roomify
 projects[roomify_property][type] = module
 projects[roomify_property][download][type] = git
 projects[roomify_property][download][url] = https://github.com/Roomify/roomify_property.git
-projects[roomify_property][download][tag] = 1.25
+projects[roomify_property][download][tag] = 1.26
 projects[roomify_property][directory_name] = roomify_property
 projects[roomify_property][subdir] = roomify
 


### PR DESCRIPTION
## Current Behavior
We currently show 3 rows in the availability calendar for each Casa - property, type and unit. 

## Expected Behavior
We should show a single row for Casa properties with the property name and the availability for its associated unit.

![screen shot 2017-07-21 at 7 26 45 am](https://user-images.githubusercontent.com/101649/28473004-43bd40ee-6e00-11e7-80c6-5a38a792b1c3.png)
