### PR TITLE
Amenities are not shown in translation on the site-wide availability search

### DIFF
--- a/modules/roomify/roomify_i18n/roomify_i18n.install
+++ b/modules/roomify/roomify_i18n/roomify_i18n.install
@@ -9,6 +9,11 @@
  * Implements hook_install().
  */
 function roomify_i18n_install() {
+  if ($vocabulary = taxonomy_vocabulary_machine_name_load('amenities')) {
+    $vocabulary->i18n_mode = I18N_MODE_ENTITY_TRANSLATION;
+]    taxonomy_vocabulary_save($vocabulary);
+
+  }
   roomify_i18n_entities_translation_settings();
 }
 
@@ -16,5 +21,17 @@ function roomify_i18n_install() {
  * Settings for properties and types translation.
  */
 function roomify_i18n_update_7001() {
+  roomify_i18n_entities_translation_settings();
+}
+
+/**
+ * Settings for properties and types translation.
+ */
+function roomify_i18n_update_7002() {
+
+  if ($vocabulary = taxonomy_vocabulary_machine_name_load('amenities')) {
+    $vocabulary->i18n_mode = I18N_MODE_ENTITY_TRANSLATION;
+    taxonomy_vocabulary_save($vocabulary);
+  }
   roomify_i18n_entities_translation_settings();
 }

--- a/modules/roomify/roomify_i18n/roomify_i18n.install
+++ b/modules/roomify/roomify_i18n/roomify_i18n.install
@@ -11,9 +11,9 @@
 function roomify_i18n_install() {
   if ($vocabulary = taxonomy_vocabulary_machine_name_load('amenities')) {
     $vocabulary->i18n_mode = I18N_MODE_ENTITY_TRANSLATION;
-]    taxonomy_vocabulary_save($vocabulary);
-
+    taxonomy_vocabulary_save($vocabulary);
   }
+
   roomify_i18n_entities_translation_settings();
 }
 
@@ -28,10 +28,10 @@ function roomify_i18n_update_7001() {
  * Settings for properties and types translation.
  */
 function roomify_i18n_update_7002() {
-
   if ($vocabulary = taxonomy_vocabulary_machine_name_load('amenities')) {
     $vocabulary->i18n_mode = I18N_MODE_ENTITY_TRANSLATION;
     taxonomy_vocabulary_save($vocabulary);
   }
+
   roomify_i18n_entities_translation_settings();
 }

--- a/modules/roomify/roomify_i18n/roomify_i18n.module
+++ b/modules/roomify/roomify_i18n/roomify_i18n.module
@@ -31,10 +31,12 @@ function roomify_i18n_form_alter(&$form, &$form_state, $form_id) {
 function roomify_i18n_entities_translation_settings() {
   $settings['default_language'] = 'xx-et-default';
   $settings['hide_language_selector'] = 1;
-  $settings['exclude_language_none '] = 0;
+  $settings['exclude_language_none'] = 1;
   $settings['lock_language'] = 0;
   $settings['shared_fields_original_only'] = 0;
 
+  variable_set('entity_translation_taxonomy', array('amenities' => 1));
+  variable_set('entity_translation_settings_taxonomy_term__amenities', $settings);
   variable_set('entity_translation_settings_roomify_property__casa_property', $settings);
   variable_set('entity_translation_settings_roomify_property__locanda_property', $settings);
   variable_set('entity_translation_settings_bat_type__home', $settings);

--- a/modules/roomify/roomify_i18n/roomify_i18n.module
+++ b/modules/roomify/roomify_i18n/roomify_i18n.module
@@ -35,7 +35,7 @@ function roomify_i18n_entities_translation_settings() {
   $settings['lock_language'] = 0;
   $settings['shared_fields_original_only'] = 0;
 
-  variable_set('entity_translation_taxonomy', array('amenities' => 1));
+  variable_set('entity_translation_taxonomy', array('amenities' => TRUE));
   variable_set('entity_translation_settings_taxonomy_term__amenities', $settings);
   variable_set('entity_translation_settings_roomify_property__casa_property', $settings);
   variable_set('entity_translation_settings_roomify_property__locanda_property', $settings);

--- a/modules/roomify/roomify_listing/roomify_listing.module
+++ b/modules/roomify/roomify_listing/roomify_listing.module
@@ -684,7 +684,7 @@ function roomify_listing_create_amenities_vocabulary() {
     'name' => 'Amenities',
     'description' => 'A vocabulary used by the Roomify Listing module to describe amenities',
     'machine_name' => 'amenities',
-    'i18n_mode' => '1',
+    'i18n_mode' => I18N_MODE_ENTITY_TRANSLATION,
   );
 
   if (!taxonomy_vocabulary_machine_name_load('amenities')) {
@@ -739,6 +739,7 @@ function roomify_listing_create_example_amenities_terms() {
     $term = new stdClass();
     $term->name = $name;
     $term->vid = $vocabulary->vid;
+    $term->language = 'en';
     taxonomy_term_save($term);
   }
 }

--- a/modules/roomify/roomify_translate/roomify_translate.install
+++ b/modules/roomify/roomify_translate/roomify_translate.install
@@ -123,3 +123,14 @@ function roomify_translate_update_7002() {
 
   _roomify_translate_replace_name_fields();
 }
+
+/**
+ * Make terms translatable.
+ */
+function roomify_translate_update_7003() {
+  if ($vocabulary = taxonomy_vocabulary_machine_name_load('amenities')) {
+    $vocabulary->i18n_mode = I18N_MODE_ENTITY_TRANSLATION;
+    taxonomy_vocabulary_save($vocabulary);
+  }
+  roomify_translate_entities_translation_settings();
+}

--- a/modules/roomify/roomify_translate/roomify_translate.module
+++ b/modules/roomify/roomify_translate/roomify_translate.module
@@ -105,7 +105,7 @@ function roomify_translate_form_alter(&$form, &$form_state, $form_id) {
 function roomify_translate_entities_translation_settings() {
   $settings['default_language'] = 'xx-et-default';
   $settings['hide_language_selector'] = 1;
-  $settings['exclude_language_none '] = 0;
+  $settings['exclude_language_none'] = 1;
   $settings['lock_language'] = 0;
   $settings['shared_fields_original_only'] = 0;
 

--- a/modules/roomify/roomify_translate/roomify_translate.module
+++ b/modules/roomify/roomify_translate/roomify_translate.module
@@ -109,6 +109,8 @@ function roomify_translate_entities_translation_settings() {
   $settings['lock_language'] = 0;
   $settings['shared_fields_original_only'] = 0;
 
+  variable_set('entity_translation_taxonomy', array('amenities' => TRUE));
+  variable_set('entity_translation_settings_taxonomy_term__amenities', $settings);
   variable_set('entity_translation_settings_roomify_property__casa_property', $settings);
   variable_set('entity_translation_settings_roomify_property__locanda_property', $settings);
   variable_set('entity_translation_settings_bat_type__home', $settings);


### PR DESCRIPTION
## Expected Behavior
Translated terms should be shown in the selected content language.

## Current Behavior
Terms are shown in english

## Steps to Reproduce from a clean installation of the latest release
1. Enable a second language
2. Translate a term to that language
3. Go to the availability search and switch the site to the second language

![pasted image at 2017_07_19 12_02 pm](https://user-images.githubusercontent.com/101649/28382272-cd6f6f56-6c7a-11e7-9af1-42caf506a903.png)
![2017-07-19 12-07-26](https://user-images.githubusercontent.com/101649/28382297-e485f246-6c7a-11e7-89bb-7a2ff0366275.png)
![pasted image at 2017_07_19 12_03 pm](https://user-images.githubusercontent.com/101649/28382325-f515c528-6c7a-11e7-9d18-ee97a5921daf.png)
