### PR TITLE
Update help text on owner profile field

### DIFF
--- a/modules/roomify/roomify_listing/roomify_listing.fields.inc
+++ b/modules/roomify/roomify_listing/roomify_listing.fields.inc
@@ -602,7 +602,7 @@ function roomify_listing_create_property_fields($property_bundle) {
       'bundle' => $property_bundle,
       'default_value' => NULL,
       'default_value_function' => '',
-      'description' => 'Enter the user name of this property\'s owner. This field defaults to this unit\'s author, but may be set to another user. This name is used for reporting purposes, displaying the owner\'s name on Conversations and other purposes.',
+      'description' => "Enter the user name of this property's owner. This field defaults to this property's author, but may be set to another user. This name is used for reporting purposes, displaying the owner's name on Conversations and displaying a property owner's name/picture. Conversation notifications and editing privileges remain with the author of this property.",
       'display' => array(
         'default' => array(
           'label' => 'above',

--- a/modules/roomify/roomify_listing/roomify_listing.install
+++ b/modules/roomify/roomify_listing/roomify_listing.install
@@ -1378,3 +1378,15 @@ function roomify_listing_update_7039() {
     field_attach_update('roomify_property', $property);
   }
 }
+
+/**
+ * Change field owner description.
+ */
+function roomify_listing_update_7040() {
+
+  foreach (array('casa_property', 'locanda_property') as $property_bundle) {
+    $instance_info = field_read_instance('roomify_property', 'field_sp_owner', $property_bundle);
+    $instance_info['description'] = "Enter the user name of this property's owner. This field defaults to this property's author, but may be set to another user. This name is used for reporting purposes, displaying the owner's name on Conversations and displaying a property owner's name/picture. Conversation notifications and editing privileges remain with the author of this property.";
+    field_update_instance($instance_info);
+  }
+}


### PR DESCRIPTION
Let's change the help text to:


Enter the user name of this property's owner. This field defaults to this property's author, but may be set to another user. This name is used for reporting purposes, displaying the owner's name on Conversations and displaying a property owner's name/picture. Conversation notifications and editing privileges remain with the author of this property.