### PR TITLE
Facet block titles on site-wide availability search should be translated 

### DIFF
--- a/modules/roomify/roomify_base_theme/roomify_base_theme.pages_default.inc
+++ b/modules/roomify/roomify_base_theme/roomify_base_theme.pages_default.inc
@@ -3360,8 +3360,8 @@ function roomify_base_theme_default_page_manager_handlers() {
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => '<span class="glyphicon glyphicon-check"></span>Area',
+    'override_title' => 0,
+    'override_title_text' => '',
     'override_title_heading' => 'h3',
   );
   $pane->cache = array();
@@ -3406,8 +3406,8 @@ function roomify_base_theme_default_page_manager_handlers() {
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => '<span class="glyphicon glyphicon-check"></span>Amenities',
+    'override_title' => 0,
+    'override_title_text' => '',
     'override_title_heading' => 'h3',
   );
   $pane->cache = array();

--- a/modules/roomify/roomify_listing/roomify_listing.install
+++ b/modules/roomify/roomify_listing/roomify_listing.install
@@ -1383,10 +1383,23 @@ function roomify_listing_update_7039() {
  * Change field owner description.
  */
 function roomify_listing_update_7040() {
-
   foreach (array('casa_property', 'locanda_property') as $property_bundle) {
     $instance_info = field_read_instance('roomify_property', 'field_sp_owner', $property_bundle);
     $instance_info['description'] = "Enter the user name of this property's owner. This field defaults to this property's author, but may be set to another user. This name is used for reporting purposes, displaying the owner's name on Conversations and displaying a property owner's name/picture. Conversation notifications and editing privileges remain with the author of this property.";
     field_update_instance($instance_info);
+  }
+}
+
+/**
+ * Resave all "amenities" terms to fill "name_field" when it is empty.
+ */
+function roomify_listing_update_7041() {
+  $vocabulary = taxonomy_vocabulary_machine_name_load('amenities');
+  $terms = entity_load('taxonomy_term', FALSE, array('vid' => $vocabulary->vid));
+
+  foreach ($terms as $term) {
+    if (empty($term->name_field)) {
+      taxonomy_term_save($term);
+    }
   }
 }

--- a/modules/roomify/roomify_system/roomify_system.install
+++ b/modules/roomify/roomify_system/roomify_system.install
@@ -821,7 +821,7 @@ function roomify_system_update_7051() {
 }
 
 /**
- * nable module "Roomify Properties List".
+ * Enable module "Roomify Properties List".
  */
 function roomify_system_update_7052() {
   module_enable(array('roomify_properties_list'));

--- a/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
+++ b/modules/roomify/roomify_travel_theme/roomify_travel_theme.pages_default.inc
@@ -873,8 +873,8 @@ function roomify_travel_theme_default_page_manager_handlers() {
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => '<span class="glyphicon glyphicon-check"></span>Area',
+    'override_title' => 0,
+    'override_title_text' => '',
     'override_title_heading' => 'h4',
   );
   $pane->cache = array();
@@ -896,8 +896,8 @@ function roomify_travel_theme_default_page_manager_handlers() {
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => 'Area Type',
+    'override_title' => 0,
+    'override_title_text' => '',
     'override_title_heading' => 'h3',
   );
   $pane->cache = array();
@@ -942,8 +942,8 @@ function roomify_travel_theme_default_page_manager_handlers() {
   $pane->shown = TRUE;
   $pane->access = array();
   $pane->configuration = array(
-    'override_title' => 1,
-    'override_title_text' => '<span class="glyphicon glyphicon-check"></span>Amenities',
+    'override_title' => 0,
+    'override_title_text' => '',
     'override_title_heading' => 'h4',
   );
   $pane->cache = array();

--- a/test/behat/features/05_booking.feature
+++ b/test/behat/features/05_booking.feature
@@ -26,7 +26,7 @@ Feature: Booking
     Then I close the better messages dialog
     Then I click "Availability" in the "My casa for bookings" row
     And I wait 10 seconds
-    Then I select dates between "2017-08-07" and "2017-08-10" for the last unit
+    Then I select dates between "2017-11-07" and "2017-11-10" for the last unit
     And I wait 10 seconds
     Then I press "Create booking"
     And I wait for AJAX to finish
@@ -57,12 +57,12 @@ Feature: Booking
 
     # Test the dashboard bookings view filters.
     Then I visit "admin/bat/bookings"
-    And I fill in "booking_start_date_value[value][date]" with "08/01/2017"
-    And I fill in "booking_end_date_value[value][date]" with "08/21/2017"
+    And I fill in "booking_start_date_value[value][date]" with "11/01/2017"
+    And I fill in "booking_end_date_value[value][date]" with "11/21/2017"
     And I fill in "name" with "My casa for bookings"
     Then I press "Apply"
-    Then I should see "2017-08-07" in the "My casa for bookings" row
-    And I should see "2017-08-09" in the "My casa for bookings" row
+    Then I should see "2017-11-07" in the "My casa for bookings" row
+    And I should see "2017-11-09" in the "My casa for bookings" row
 
     Then I visit "admin/bat/bookings"
     And I fill in "booking_start_date_value[value][date]" with "05/01/2017"

--- a/test/behat/features/12_offers.feature
+++ b/test/behat/features/12_offers.feature
@@ -15,14 +15,14 @@ Feature: Special offers
     And I select the radio button "Flat"
     And I fill in "bat_start_date[date]" with "2016-10-01"
     And I fill in "bat_start_date[time]" with "00:00"
-    And I fill in "bat_end_date[date]" with "2017-10-01"
+    And I fill in "bat_end_date[date]" with "2017-12-01"
     And I fill in "bat_end_date[time]" with "00:00"
     Then I press "Create"
     And I wait 10 seconds
 
     Then I visit "admin/bat/config/global/offers/calendar"
     And I wait 10 seconds
-    Then I select dates between "2017-08-01" and "2017-08-28" for the last rate
+    Then I select dates between "2017-10-01" and "2017-10-28" for the last rate
     And I wait 10 seconds
     Then I fill in "pricing_event_price[und][0][amount]" with "5"
     And I press "Update value"
@@ -31,7 +31,7 @@ Feature: Special offers
     Then I visit "admin/bat/config/property/manage/1/offers"
     And I click on "Participate" on the row containing "Flat offer"
 
-    Then I visit "booking/2017-08-02/2017-08-05/1"
+    Then I visit "booking/2017-10-02/2017-10-05/1"
     And I should see "$15.00" in the ".current-search-item.current-search-price .offer-cost" element
     And I should see "$15.00" in the "#roomify-accommodation-booking-confirmation-form .price .offer-cost" element
 
@@ -49,14 +49,14 @@ Feature: Special offers
     And I select the radio button "Percentage"
     And I fill in "bat_start_date[date]" with "2016-10-01"
     And I fill in "bat_start_date[time]" with "00:00"
-    And I fill in "bat_end_date[date]" with "2017-10-01"
+    And I fill in "bat_end_date[date]" with "2017-12-01"
     And I fill in "bat_end_date[time]" with "00:00"
     Then I press "Create"
     And I wait 10 seconds
 
     Then I visit "admin/bat/config/global/offers/calendar"
     And I wait 10 seconds
-    Then I select dates between "2017-10-01" and "2017-10-30" for the last rate
+    Then I select dates between "2017-12-01" and "2017-12-30" for the last rate
     And I wait 10 seconds
     Then I fill in "pricing_discount[und][0][value]" with "50"
     And I press "Update value"
@@ -66,6 +66,6 @@ Feature: Special offers
     And I click on "Participate" on the row containing "Percentage offer"
     And I visit "listing/1"
     And I should see "Percentage offer"
-    Then I visit "booking/2017-10-02/2017-10-05/1"
+    Then I visit "booking/2017-12-02/2017-12-05/1"
     And I should see "$30.00" in the ".current-search-item.current-search-price .offer-cost" element
     And I should see "$30.00" in the "#roomify-accommodation-booking-confirmation-form .price .offer-cost" element

--- a/themes/roomify/roomify_bootstrap/template.php
+++ b/themes/roomify/roomify_bootstrap/template.php
@@ -351,5 +351,32 @@ function roomify_bootstrap_preprocess_mimemail_message(&$variables) {
   $variables['footer_border'] = roomify_system_adjust_brightness($footer_bg, -25);
   $variables['header_color'] = $header_color;
   $variables['footer_color'] = $footer_color;
+}
 
+/**
+ * Implements theme_facetapi_title().
+ */
+function roomify_bootstrap_facetapi_title($variables) {
+  global $language;
+
+  if ($variables['facet']['#facet']['name'] == 'property_bat_type_reference:field_st_amenities') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('amenities');
+    $name = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+
+    $variables['title'] = '<span class="glyphicon glyphicon-check"></span>' . $name;
+  }
+  elseif ($variables['facet']['#facet']['name'] == 'field_sp_area') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('location');
+    $name = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+
+    $variables['title'] = '<span class="glyphicon glyphicon-check"></span>' . $name;
+  }
+  elseif ($variables['facet']['#facet']['name'] == 'field_sp_area_type') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('area_type');
+    $name = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+
+    $variables['title'] = $name;
+  }
+
+  return $variables['title'];
 }

--- a/themes/roomify/roomify_bootstrap_wide/template.php
+++ b/themes/roomify/roomify_bootstrap_wide/template.php
@@ -351,5 +351,32 @@ function roomify_bootstrap_wide_preprocess_mimemail_message(&$variables) {
   $variables['footer_border'] = roomify_system_adjust_brightness($footer_bg, -25);
   $variables['header_color'] = $header_color;
   $variables['footer_color'] = $footer_color;
+}
 
+/**
+ * Implements theme_facetapi_title().
+ */
+function roomify_bootstrap_wide_facetapi_title($variables) {
+  global $language;
+
+  if ($variables['facet']['#facet']['name'] == 'property_bat_type_reference:field_st_amenities') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('amenities');
+    $name = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+
+    $variables['title'] = '<span class="glyphicon glyphicon-check"></span>' . $name;
+  }
+  elseif ($variables['facet']['#facet']['name'] == 'field_sp_area') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('location');
+    $name = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+
+    $variables['title'] = '<span class="glyphicon glyphicon-check"></span>' . $name;
+  }
+  elseif ($variables['facet']['#facet']['name'] == 'field_sp_area_type') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('area_type');
+    $name = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+
+    $variables['title'] = $name;
+  }
+
+  return $variables['title'];
 }

--- a/themes/roomify/roomify_travel/template.php
+++ b/themes/roomify/roomify_travel/template.php
@@ -360,3 +360,25 @@ function roomify_travel_preprocess_page(&$variables) {
     $variables['theme_hook_suggestions'][] = 'page__locanda_listing';
   }
 }
+
+/**
+ * Implements theme_facetapi_title().
+ */
+function roomify_travel_facetapi_title($variables) {
+  global $language;
+
+  if ($variables['facet']['#facet']['name'] == 'property_bat_type_reference:field_st_amenities') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('amenities');
+    $variables['title'] = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+  }
+  elseif ($variables['facet']['#facet']['name'] == 'field_sp_area') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('location');
+    $variables['title'] = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+  }
+  elseif ($variables['facet']['#facet']['name'] == 'field_sp_area_type') {
+    $vocabulary = taxonomy_vocabulary_machine_name_load('area_type');
+    $variables['title'] = i18n_taxonomy_vocabulary_name($vocabulary, $language->language);
+  }
+
+  return $variables['title'];
+}


### PR DESCRIPTION
## Expected Behavior
When a vocabulary title (such as Amenities) is translated, that title should be shown in translation on the site-wide search when browsing in another language.

## Current Behavior
The english title is displayed.

## Steps to Reproduce from a clean installation of the latest release
1. Enable a second language
2. Translate the Amenities vocabulary title
3. Go to the site-wide search
