### PR TITLE
Fill first name and last name on a new user creation (from booking checkout)

### DIFF
--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.module
@@ -1335,23 +1335,26 @@ function roomify_accommodation_booking_default_cer() {
 function roomify_accommodation_booking_entity_insert($entity, $type) {
   // We should check if the profile is set on the User field.
   if ($type == 'commerce_customer_profile') {
-    if ($entity->uid != 0 && $user = user_load($entity->uid)) {
+    if ($entity->uid && ($user = user_load($entity->uid))) {
+      $exists = FALSE;
+
       if ($commerce_profiles = field_get_items('user', $user, 'user_commerce_profile')) {
-        $exists = FALSE;
         foreach ($commerce_profiles as $commerce_profile) {
           if ($commerce_profile['target_id'] == $entity->profile_id) {
             $exists = TRUE;
             break;
           }
         }
-        if (!$exists) {
-          // Let's add a new reference to the field.
-          $user->user_commerce_profile[LANGUAGE_NONE][]['target_id'] = $entity->profile_id;
-          field_attach_update('user', $user);
-        }
+      }
+
+      if (!$exists) {
+        // Let's add a new reference to the field.
+        $user->user_commerce_profile[LANGUAGE_NONE][]['target_id'] = $entity->profile_id;
+        field_attach_update('user', $user);
       }
     }
   }
+
   if ($type == 'bat_type') {
     if ($entity->type == 'home' || $entity->type == 'room') {
       global $user;
@@ -1551,6 +1554,27 @@ function roomify_accommodation_booking_entity_insert($entity, $type) {
  * Implements hook_entity_update().
  */
 function roomify_accommodation_booking_entity_update($entity, $type) {
+  if ($type == 'commerce_customer_profile') {
+    if ($entity->original->uid == 0 && ($user = user_load($entity->uid))) {
+      $exists = FALSE;
+
+      if ($commerce_profiles = field_get_items('user', $user, 'user_commerce_profile')) {
+        foreach ($commerce_profiles as $commerce_profile) {
+          if ($commerce_profile['target_id'] == $entity->profile_id) {
+            $exists = TRUE;
+            break;
+          }
+        }
+      }
+
+      if (!$exists) {
+        // Let's add a new reference to the field.
+        $user->user_commerce_profile[LANGUAGE_NONE][]['target_id'] = $entity->profile_id;
+        field_attach_update('user', $user);
+      }
+    }
+  }
+
   if ($type == 'bat_type') {
     if ($entity->type == 'home' || $entity->type == 'room') {
       if (isset($entity->field_st_property_reference[LANGUAGE_NONE][0]['target_id'])) {

--- a/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.rules_defaults.inc
+++ b/modules/roomify/roomify_accommodation_booking/roomify_accommodation_booking.rules_defaults.inc
@@ -62,6 +62,16 @@ function roomify_accommodation_booking_default_rules_configuration() {
                       "data" : [ "commerce-order:owner:user-address" ],
                       "value" : [ "customer-profile:commerce-customer-address" ]
                     }
+                  },
+                  { "data_set" : {
+                      "data" : [ "commerce-order:owner:user-first-name" ],
+                      "value" : [ "customer-profile:commerce-customer-address:first-name" ]
+                    }
+                  },
+                  { "data_set" : {
+                      "data" : [ "commerce-order:owner:user-last-name" ],
+                      "value" : [ "customer-profile:commerce-customer-address:last-name" ]
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
If I create a new booking as an anonymous I should have first name and last name (user entity) filled with the ones I used during the checkout (commerce profile). I think we could split the "Full Name" field of the customer profile in First and Last name if it could results easier.

We should also add the customer profile created to the user's billing profiles (field in the user entity).

<img width="744" alt="screen shot 2017-07-31 at 10 53 20" src="https://user-images.githubusercontent.com/6781952/28770273-d77621a8-75de-11e7-842a-8223ef5dfd3f.png">
