### PR TITLE
Fix calendar view on small devices

### DIFF
--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -6758,6 +6758,10 @@ blockquote {
     color: #127ba3;
     font-weight: 400; }
 
+@media (max-width: 620px) {
+  #ui-datepicker-div {
+    width: 20em !important; } }
+
 .ui-tabs {
   padding: 0 !important;
   border: 0;

--- a/themes/roomify/roomify_travel/assets/sass/components/_datepicker.scss
+++ b/themes/roomify/roomify_travel/assets/sass/components/_datepicker.scss
@@ -109,3 +109,9 @@
     font-weight: 400;
   }
 }
+
+#ui-datepicker-div {
+  @media (max-width: 620px) {
+    width: 20em !important;
+  }
+}

--- a/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
+++ b/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
@@ -80,6 +80,12 @@ Drupal.behaviors.roomifyTravelScripts = {
       $('.page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block:not(#availability-search-facet) .pane-title').addClass('hidden-content');
       $('.page-availability-search .panel-sl-left-content-wrapper .panel_sl_left .panel-pane.pane-block:not(#availability-search-facet) .pane-content').hide();
     }
+
+    if ($(window).width() <= 620) {
+      $('.form-type-date-popup input').datepicker({
+        numberOfMonths: 1
+      });
+    }
   }
 };
 
@@ -164,6 +170,5 @@ Drupal.behaviors.roomifyTravelHomepageScripts = {
     }
   }
 };
-
 
 })(jQuery);


### PR DESCRIPTION
If a user makes a search on the listing page with a mobile device the calendar will overflow the page

<img width="453" alt="screen shot 2017-09-27 at 11 22 11" src="https://user-images.githubusercontent.com/6781952/30905827-4c6c15ca-a376-11e7-8ff0-d640335518f0.png">
