### PR TITLE
On mobile only:  The value input for field Arrival is invalid. Same for departure

### DIFF
--- a/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
+++ b/themes/roomify/roomify_travel/assets/scripts/roomify_travel.js
@@ -82,9 +82,9 @@ Drupal.behaviors.roomifyTravelScripts = {
     }
 
     if ($(window).width() <= 620) {
-      $('.form-type-date-popup input').datepicker({
-        numberOfMonths: 1
-      });
+      for (var id in Drupal.settings.datePopup) {
+        Drupal.settings.datePopup[id].settings.numberOfMonths = 1;
+      }
     }
   }
 };


### PR DESCRIPTION

<!--- Provide a general summary of the issue in the Title above -->

## Expected Behavior
<!--- Tell us what you believe should happen. -->

I should just see the search results.

## Current Behavior
<!--- Tell us what happens instead of the expected behavior. -->

With a clean installation and no date format settings modified (see BAT PHP Date Format attached), when I select arrival and departure dates and click search I get the error attached in screenshot.
It only happens on mobiles in different browsers.  This was noticed in Europe.
This doesn't happen on desktop (I even tried mobile screen size).

## Possible Solution
<!--- Not obligatory, but feel free to suggest a fix for the bug. -->

## Steps to Reproduce from a clean installation of the latest release
<!--- Please provide an unambiguous set of steps to reproduce this bug. -->

With a clean installation and no date format settings modified (see BAT PHP Date Format attached), when I select arrival and departure dates and click search I get the error attached in screenshot.
It only happens on mobiles in different browsers. 


<!--- Screenshots and URLs of the pages in question are extremely helpful. -->
1.
![bat_date](https://user-images.githubusercontent.com/11167425/32796112-a5df2560-c965-11e7-9011-7ea7a66f4551.png)

2.
![screenshot_20171114-175706](https://user-images.githubusercontent.com/11167425/32796802-c4a57088-c967-11e7-8b36-605627f2f6a8.png)

3.
![screenshot_20171114-175713](https://user-images.githubusercontent.com/11167425/32796811-c92fcb8a-c967-11e7-8cf4-624f7a2b390c.png)

4.

## Context (Environment)
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- What OS/browser versions have you reproduced this issue with? -->Samsung Galaxy S8
<!--- Providing context helps us come up with a broadly applicable solution. -->In Europe
