### PR TITLE
Disallow urls from robots.txt

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -6,4 +6,4 @@ projects[drupal][version] = 7.56
 projects[drupal][patch][] = "http://drupal.org/files/issues/install-redirect-on-empty-database-728702-36.patch"
 projects[drupal][patch][] = "http://drupal.org/files/1275902-15-entity_uri_callback-D7.patch"
 projects[drupal][patch][] = "patches/9to10_menu_max_parts.patch"
-projects[drupal][patch][] = "patches/exclude_flag_robottxt.patch"
+projects[drupal][patch][] = "patches/robots_txt.patch"

--- a/patches/exclude_flag_robottxt.patch
+++ b/patches/exclude_flag_robottxt.patch
@@ -1,9 +1,0 @@
-diff --git a/robots.txt b/robots.txt
-index ff9e286..fc8153a 100644
---- a/robots.txt
-+++ b/robots.txt
-@@ -55,3 +55,4 @@ Disallow: /?q=user/password/
- Disallow: /?q=user/register/
- Disallow: /?q=user/login/
- Disallow: /?q=user/logout/
-+Disallow: /flag/

--- a/patches/robots_txt.patch
+++ b/patches/robots_txt.patch
@@ -1,0 +1,23 @@
+diff --git a/robots.txt b/robots.txt
+index a2ee32e..99252ad 100644
+--- a/robots.txt
++++ b/robots.txt
+@@ -78,6 +78,10 @@ Disallow: /user/register/
+ Disallow: /user/password/
+ Disallow: /user/login/
+ Disallow: /user/logout/
++Disallow: /user/
++Disallow: /flag/
++Disallow: /type-availability-calendar/
++Disallow: /*/type-availability-calendar/
+ # Paths (no clean URLs)
+ Disallow: /?q=admin/
+ Disallow: /?q=comment/reply/
+@@ -88,3 +92,7 @@ Disallow: /?q=user/password/
+ Disallow: /?q=user/register/
+ Disallow: /?q=user/login/
+ Disallow: /?q=user/logout/
++Disallow: /?q=user/
++Disallow: /?q=flag/
++Disallow: /?q=type-availability-calendar/
++Disallow: /?q=*/type-availability-calendar/


### PR DESCRIPTION
Disallow /user and /type-availability-calendar urls from robots.txt

Be careful about languages (e.g. /it/type-availability-calendar should be added to)