### PR TITLE
Remove duplicate links when using both menu and node sitemap

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -536,7 +536,10 @@ projects[wysiwyg][version] = 2.4
 
 projects[xautoload][version] = 5.7
 
-projects[xmlsitemap][version] = 2.3
+projects[xmlsitemap][type] = module
+projects[xmlsitemap][download][type] = git
+projects[xmlsitemap][download][url] = https://git.drupal.org/project/xmlsitemap.git
+projects[xmlsitemap][download][revision] = eaaf1dd750c17ccca9c58cf40d1cda815b77cbb2
 projects[xmlsitemap][patch][] = https://www.drupal.org/files/issues/xmlsitemap-entity-integration-1461670-38.patch
 
 projects[yoast_seo][type] = module


### PR DESCRIPTION
I found that if you enable both modules the xml sitemap will contain duplicated content.  Hopefully this patch fix the issue.
https://www.drupal.org/project/xmlsitemap/issues/2257191