### PR TITLE
Global enquiry sent page

### DIFF
--- a/modules/roomify/roomify_contact/roomify_contact.features.inc
+++ b/modules/roomify/roomify_contact/roomify_contact.features.inc
@@ -55,7 +55,7 @@ function roomify_contact_default_entityform_type() {
         "163670334" : 0
       },
       "resubmit_action" : "new",
-      "redirect_path" : "\u003Cfront\u003E",
+      "redirect_path" : "contact-us\/done",
       "instruction_pre" : { "value" : "", "format" : "plain_text" },
       "current_type" : "contact",
       "enable_block" : 1

--- a/modules/roomify/roomify_contact/roomify_contact.install
+++ b/modules/roomify/roomify_contact/roomify_contact.install
@@ -165,3 +165,15 @@ function roomify_contact_update_7005() {
   $conversations_mlid = roomify_system_get_menu_link_id('Conversations', 'admin/bat/conversations/guest', 'roomify_dashboard_menu');
   roomify_system_create_update_menu_link('Site Wide contact enquiries', 'admin/structure/entityform_types/manage/contact/submissions/autofields_table', 'roomify_dashboard_menu', 5, 1, $conversations_mlid);
 }
+
+/**
+ * Change "Contact" redirect path.
+ */
+function roomify_contact_update_7006() {
+  $entityform_type = entityform_type_load('contact');
+
+  if ($entityform_type->data['redirect_path'] != 'contact-us/done') {
+    $entityform_type->data['redirect_path'] = 'contact-us/done';
+    $entityform_type->save();
+  }
+}

--- a/modules/roomify/roomify_contact/roomify_contact.module
+++ b/modules/roomify/roomify_contact/roomify_contact.module
@@ -8,6 +8,29 @@
 include_once 'roomify_contact.features.inc';
 
 /**
+ * Implements hook_menu().
+ */
+function roomify_contact_menu() {
+  $items = array();
+
+  $items['contact-us/done'] = array(
+    'title' => 'Enquiry sent successfully!',
+    'page callback' => 'roomify_contact_done_page',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
+ * Contact us done page.
+ */
+function roomify_contact_done_page() {
+  return t('Thank you! Your enquiry has been received and we will get back to you soon!');
+}
+
+/**
  * Send email to managers when a new contact form is submitted.
  */
 function roomify_contact_notify_managers($entityform, $settings, $rules_state) {


### PR DESCRIPTION
when a user submits a global inquiry (from the /contact-us page) we should bring him in another page (/contact-us/done).

TItle: Enquiry sent successfully!
Text: Thank you! Your enquiry has been received and we will get back to you soon!