### PR TITLE
Remove suspendend properties from the xmlsitemap

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -34,7 +34,7 @@ projects[roomify_rate][subdir] = roomify
 projects[roomify_property][type] = module
 projects[roomify_property][download][type] = git
 projects[roomify_property][download][url] = https://github.com/Roomify/roomify_property.git
-projects[roomify_property][download][tag] = 1.26
+projects[roomify_property][download][tag] = 1.29
 projects[roomify_property][directory_name] = roomify_property
 projects[roomify_property][subdir] = roomify
 


### PR DESCRIPTION
Suspended properties should be removed from the xml sitemap because they return a 403 error.