### PR TITLE
A manager should be able to add a text on the contact-us page

### DIFF
--- a/modules/roomify/roomify_contact/plugins/content_types/roomify_contact_us_page_text.inc
+++ b/modules/roomify/roomify_contact/plugins/content_types/roomify_contact_us_page_text.inc
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Plugin definition and callbacks for a ctools:content_types plugin.
+ *
+ * @ingroup CToolsPlugin CToolsPluginContentTypes
+ */
+
+$plugin = array(
+  'category' => t('Roomify'),
+  'title' => t('Roomify Contact-us page text'),
+  'description' => t('Roomify Contact-us page text.'),
+  'render callback' => 'roomify_contact_us_page_text_render',
+);
+
+/**
+ * Render callback.
+ */
+function roomify_contact_us_page_text_render($subtype, $conf, $args, $pane_context, $incoming_content) {
+  global $language;
+
+  variable_realm_switch('language', $language->language);
+
+  $page_text = variable_get_value('roomify_contact_page_text', array('language' => $language));
+
+  $block = new stdClass();
+  $block->title = '';
+  $block->content = check_markup($page_text['value'], $page_text['format']);
+
+  return $block;
+}

--- a/modules/roomify/roomify_contact/roomify_contact.install
+++ b/modules/roomify/roomify_contact/roomify_contact.install
@@ -177,3 +177,13 @@ function roomify_contact_update_7006() {
     $entityform_type->save();
   }
 }
+
+/**
+ * Add 'Contact-us page text' variable as translatable.
+ */
+function roomify_contact_update_7007() {
+  $variable_realm_list = variable_get('variable_realm_list_language', array());
+  $variable_realm_list[] = 'roomify_contact_page_text';
+
+  variable_set('variable_realm_list_language', $variable_realm_list);
+}

--- a/modules/roomify/roomify_contact/roomify_contact.module
+++ b/modules/roomify/roomify_contact/roomify_contact.module
@@ -20,7 +20,25 @@ function roomify_contact_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['admin/structure/entityform_types/manage/%entityform_type/page_text'] = array(
+    'title' => 'Page text',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('roomify_contact_page_text_form'),
+    'access arguments' => array('view any entityform'),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 200,
+  );
+
   return $items;
+}
+
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+function roomify_contact_ctools_plugin_directory($owner, $plugin_type) {
+  if ($owner == 'ctools' && $plugin_type == 'content_types') {
+    return 'plugins/content_types';
+  }
 }
 
 /**
@@ -88,4 +106,36 @@ function roomify_contact_page_alter(&$page) {
     // Kill breadcrumb, set to empty array.
     drupal_set_breadcrumb(array());
   }
+}
+
+/**
+ * Contact-us page text configuration form.
+ */
+function roomify_contact_page_text_form($form, &$form_state) {
+  form_load_include($form_state, 'inc', 'variable_realm', 'variable_realm.variable');
+  module_load_include('form.inc', 'variable');
+  _roomify_system_prepare_variables_realm();
+
+  $form['description'] = array(
+    '#markup' => '<h4>' . t('This text will be used on the contact us page.') . '</h4>',
+  );
+
+  $form['roomify_contact_page_text'] = variable_form_element(variable_get_info('roomify_contact_page_text'));
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+  );
+
+  $form['#submit'] = array('roomify_contact_page_text_form_submit');
+  variable_realm_variable_settings_form_alter($form, $form_state, 'roomify_contact_page_text_form');
+
+  return $form;
+}
+
+/**
+ * Submit function for the roomify_contact_page_text_form form.
+ */
+function roomify_contact_page_text_form_submit($form, &$form_state) {
+  drupal_set_message(t('The configuration options have been saved'));
 }

--- a/modules/roomify/roomify_contact/roomify_contact.pages_default.inc
+++ b/modules/roomify/roomify_contact/roomify_contact.pages_default.inc
@@ -45,7 +45,7 @@ function roomify_contact_default_page_manager_pages() {
     'name' => 'panel',
   );
   $display = new panels_display();
-  $display->layout = 'bootstrap_one_column';
+  $display->layout = 'bootstrap_sidebar_right';
   $display->layout_settings = array();
   $display->panel_settings = array(
     'style_settings' => array(
@@ -59,11 +59,13 @@ function roomify_contact_default_page_manager_pages() {
   $display->cache = array();
   $display->title = 'Get in touch';
   $display->uuid = 'cb4cbc4b-ae3a-411c-8265-147ad664f024';
+  $display->storage_type = 'page_manager';
+  $display->storage_id = 'page_contact__panel';
   $display->content = array();
   $display->panels = array();
   $pane = new stdClass();
   $pane->pid = 'new-c721bf2b-1b39-4379-896b-b54b1096311d';
-  $pane->panel = 'middle';
+  $pane->panel = 'left';
   $pane->type = 'block';
   $pane->subtype = 'entityform_block-contact';
   $pane->shown = TRUE;
@@ -83,7 +85,26 @@ function roomify_contact_default_page_manager_pages() {
   $pane->locks = array();
   $pane->uuid = 'c721bf2b-1b39-4379-896b-b54b1096311d';
   $display->content['new-c721bf2b-1b39-4379-896b-b54b1096311d'] = $pane;
-  $display->panels['middle'][0] = 'new-c721bf2b-1b39-4379-896b-b54b1096311d';
+  $display->panels['left'][0] = 'new-c721bf2b-1b39-4379-896b-b54b1096311d';
+  $pane = new stdClass();
+  $pane->pid = 'new-4a34b50e-5006-4cc3-898e-44a92f4ed1d2';
+  $pane->panel = 'right';
+  $pane->type = 'roomify_contact_us_page_text';
+  $pane->subtype = 'roomify_contact_us_page_text';
+  $pane->shown = TRUE;
+  $pane->access = array();
+  $pane->configuration = array();
+  $pane->cache = array();
+  $pane->style = array(
+    'settings' => NULL,
+  );
+  $pane->css = array();
+  $pane->extras = array();
+  $pane->position = 0;
+  $pane->locks = array();
+  $pane->uuid = '4a34b50e-5006-4cc3-898e-44a92f4ed1d2';
+  $display->content['new-4a34b50e-5006-4cc3-898e-44a92f4ed1d2'] = $pane;
+  $display->panels['right'][0] = 'new-4a34b50e-5006-4cc3-898e-44a92f4ed1d2';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = 'new-c721bf2b-1b39-4379-896b-b54b1096311d';
   $handler->conf['display'] = $display;

--- a/modules/roomify/roomify_contact/roomify_contact.variable.inc
+++ b/modules/roomify/roomify_contact/roomify_contact.variable.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Variable module integration for the Roomify Contact module.
+ */
+
+/**
+ * Implements hook_variable_info().
+ */
+function roomify_contact_variable_info($options = array()) {
+  $variables['roomify_contact_page_text'] = array(
+    'type' => 'text_format',
+    'title' => t('Contact-us page text'),
+    'default' => '',
+    'localize' => TRUE,
+    'group' => 'roomify',
+  );
+
+  return $variables;
+}

--- a/modules/roomify/roomify_review/roomify_review.module
+++ b/modules/roomify/roomify_review/roomify_review.module
@@ -8,7 +8,7 @@
 include_once 'roomify_review.features.inc';
 
 /**
- * Implements hook_ctools_plugin_directory()
+ * Implements hook_ctools_plugin_directory().
  */
 function roomify_review_ctools_plugin_directory($owner, $plugin_type) {
   if ($owner == 'ctools' && $plugin_type == 'content_types') {

--- a/themes/roomify/roomify_travel/assets/css/style.css
+++ b/themes/roomify/roomify_travel/assets/css/style.css
@@ -9781,6 +9781,17 @@ body.toggled #close-sidebar-wrapper {
   .page-contact-us .region-content:after,
   .page-contact-us .bootstrap-one-column:after {
     clear: both; }
+.page-contact-us .region-content .panel-pane {
+  margin-bottom: 15px;
+  display: inline-block;
+  width: 100%;
+  padding: 15px;
+  background: white;
+  border: 1px solid #ececec;
+  border-radius: 2px; }
+  .page-contact-us .region-content .panel-pane .pane-title {
+    border-bottom: 1px solid #ececec;
+    padding-bottom: 15px; }
 .page-contact-us .panel_sl_content {
   padding: 0; }
 .page-contact-us .panel {

--- a/themes/roomify/roomify_travel/assets/sass/pages/_contact.scss
+++ b/themes/roomify/roomify_travel/assets/sass/pages/_contact.scss
@@ -5,6 +5,21 @@
   .bootstrap-one-column {
     @include make-row();
   }
+  .region-content {
+    .panel-pane {
+      margin-bottom: 15px;
+      display: inline-block;
+      width: 100%;
+      padding: 15px;
+      background: white;
+      border: 1px solid #ececec;
+      border-radius: 2px;
+      .pane-title {
+        border-bottom: 1px solid #ececec;
+        padding-bottom: 15px
+      }
+    }
+  }
   .panel_sl_content {
     padding: 0;
   }


### PR DESCRIPTION
I was thinking to alter the form on the page /admin/structure/entityform_types/manage/contact/submissions (accessible by roomify manager) and add a variable to save a custom text to show on the contact-us page.

The page should have 2 columns (66% and 33%) and shows the form and the text.