### PR TITLE
Long load times for 'Manage House' tab when thousands of properties are present

### DIFF
--- a/modules/roomify/roomify_listing/roomify_listing.fields.inc
+++ b/modules/roomify/roomify_listing/roomify_listing.fields.inc
@@ -2917,11 +2917,7 @@ function roomify_listing_create_standard_type_fields($type_bundle) {
         'user_register_form' => FALSE,
       ),
       'widget' => array(
-        'active' => 1,
-        'module' => 'options',
-        'settings' => array(),
-        'type' => 'options_select',
-        'weight' => 11,
+        'type' => 'entityreference_autocomplete',
       ),
     );
   }

--- a/modules/roomify/roomify_listing/roomify_listing.install
+++ b/modules/roomify/roomify_listing/roomify_listing.install
@@ -1501,3 +1501,16 @@ function roomify_listing_update_7044() {
     }
   }
 }
+
+/**
+ * Change widget to "Autocomplete" for "field_st_property_reference".
+ */
+function roomify_listing_update_7045() {
+  foreach (array('home', 'room') as $type_bundle) {
+    $instance_info = field_read_instance('bat_type', 'field_st_property_reference', $type_bundle);
+    $instance_info['widget'] = array(
+      'type' => 'entityreference_autocomplete',
+    );
+    field_update_instance($instance_info);
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->
I am working on Roomify development for one of my client and we are facing issue with the Manage house and multi currency issue in the property. 
## Expected Behavior
<!--- Tell us what you believe should happen. -->
Multi currency should be supported and Manage house Tab must load very quick. 
## Current Behavior
<!--- Tell us what happens instead of the expected behavior. -->
I tried to set 2 currency (CAD / USD), but system is showing only CAD.
I have 4500 property and each property has manage house  Tab and it is taking 5 - 6 minute to load. 

## Possible Solution
<!--- Not obligatory, but feel free to suggest a fix for the bug. -->
Look like issue is in DB related.
## Steps to Reproduce from a clean installation of the latest release
<!--- Please provide an unambiguous set of steps to reproduce this bug. -->
<!--- Screenshots and URLs of the pages in question are extremely helpful. -->
1.
2.
3.
4.

## Context (Environment)
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- What OS/browser versions have you reproduced this issue with? -->
<!--- Providing context helps us come up with a broadly applicable solution. -->
