### PR TITLE
Improve global calendar UX

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -34,7 +34,7 @@ projects[roomify_rate][subdir] = roomify
 projects[roomify_property][type] = module
 projects[roomify_property][download][type] = git
 projects[roomify_property][download][url] = https://github.com/Roomify/roomify_property.git
-projects[roomify_property][download][tag] = 1.29
+projects[roomify_property][download][tag] = 1.30
 projects[roomify_property][directory_name] = roomify_property
 projects[roomify_property][subdir] = roomify
 

--- a/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
+++ b/themes/roomify/roomify_adminimal_theme/css/roomify_adminimal_theme.css
@@ -714,6 +714,10 @@ body.adminimal-theme .autocomplete-deluxe-item {
 .fc-ltr .fc-timeline-event .fc-bg {
   opacity: 0;
 }
+.view-availability-calendar #availability-calendar {
+  height: calc(100vh - 300px);
+  min-height: 350px;
+}
 .view-availability-calendar .fc-ltr .fc-timeline-event {
   top: 2% !important;
   height: 98%;

--- a/themes/roomify/roomify_adminimal_theme/less/components/calendars.less
+++ b/themes/roomify/roomify_adminimal_theme/less/components/calendars.less
@@ -13,6 +13,10 @@
   }
 }
 .view-availability-calendar {
+  #availability-calendar {
+    height: calc(100vh - 300px);
+    min-height: 350px;
+  }
   .fc-ltr .fc-timeline-event {
     top: 2% !important;
     height: 98%;


### PR DESCRIPTION
<img width="1313" alt="screen shot 2018-02-15 at 15 01 01" src="https://user-images.githubusercontent.com/6781952/36260304-39a73da2-1261-11e8-922e-e01d31d45b17.png">
When there a lot of properties it becomes hard to manage those in the global calendar. We should keep the <thead> fixed at the top of the page when scrolling so dates are always available.